### PR TITLE
Convert user messages to net messages.

### DIFF
--- a/cfg/reloadfish.cfg
+++ b/cfg/reloadfish.cfg
@@ -6,3 +6,4 @@ lua_reloadent fishing_mod_shelf
 lua_reloadent fishing_mod_base
 lua_reloadent fishing_mod_seagull
 lua_openscript_cl fishing_mod/cl_init.lua
+aowl l include[[autorun/fishing_mod_init.lua]]

--- a/cfg/reloadfish.cfg
+++ b/cfg/reloadfish.cfg
@@ -6,4 +6,3 @@ lua_reloadent fishing_mod_shelf
 lua_reloadent fishing_mod_base
 lua_reloadent fishing_mod_seagull
 lua_openscript_cl fishing_mod/cl_init.lua
-aowl l include[[autorun/fishing_mod_init.lua]]

--- a/lua/fishing_mod/cl_networking.lua
+++ b/lua/fishing_mod/cl_networking.lua
@@ -22,25 +22,25 @@ local function FriedToFriendly(number)
 	end
 end
 
-usermessage.Hook("Fishingmod:BaitPrices", function(um)
-	local name = um:ReadString()
-	local multiplier = um:ReadFloat()
+net.Receive("Fishingmod:BaitPrices", function()
+	local name = net.ReadString()
+	local multiplier = net.ReadFloat()
 	if not fishingmod.BaitTable[name] then return end
 	fishingmod.BaitTable[name].multiplier = multiplier
 	fishingmod.UpdateSales()
 end)
 
 
-local function UpdatePlayer(ply,um) 
+local function UpdatePlayer(ply) 
 	
-	local exp = um:ReadLong()
-	local catch = um:ReadLong()
-	local money = um:ReadLong()
-	local length = um:ReadChar()
-	local reel_speed = um:ReadChar()
-	local string_length = um:ReadShort()
-	local force = um:ReadShort()
-	local spawned = um:ReadBool()
+	local exp = net.ReadInt(32)
+	local catch = net.ReadInt(32)
+	local money = net.ReadInt(32)
+	local length = net.ReadInt(8)
+	local reel_speed = net.ReadInt(8)
+	local string_length = net.ReadInt(16)
+	local force = net.ReadInt(16)
+	local spawned = net.ReadBool()
 	ply.fishingmod=ply.fishingmod or {}
 	if not ply.fishingmod then return end
 	ply.fishingmod.length = length
@@ -61,36 +61,36 @@ local function UpdatePlayer(ply,um)
 	end
 end
 
-local function UpdatePlayerWait(ply,um,time)
+local function UpdatePlayerWait(ply,time)
 	if time<CurTime() then return end
 	if IsValid(ply) and ply:IsPlayer() then
 		ply.fishingmod = ply.fishingmod or {}
 		if ply.fishingmod then
 			--print("Delayed update",ply)
-			UpdatePlayer(ply,um)
+			UpdatePlayer(ply)
 			return
 		end
 	end
 	timer.Simple(0.5,function() 
-		UpdatePlayerWait(ply,um,time)
+		UpdatePlayerWait(ply,time)
 	end)
 end
 
-usermessage.Hook("Fishingmod:Player", function(um) 
-	local ply = um:ReadEntity()
+net.Receive("Fishingmod:Player", function() 
+	local ply = net.ReadEntity()
 	if not IsValid(ply) or not ply:IsPlayer() or not ply.fishingmod then
-		UpdatePlayerWait(ply,um,CurTime()+5)
+		UpdatePlayerWait(ply,CurTime()+5)
 	end
-	UpdatePlayer(ply,um)
+	UpdatePlayer(ply)
 end)
 
-usermessage.Hook("Fishingmod:Catch", function(um) 
-	local entity = um:ReadShort()
-	local friendly = um:ReadString()
-	local caught = um:ReadLong()
-	local owner = um:ReadString()
-	local fried = um:ReadShort()
-	local value = um:ReadLong()
+net.Receive("Fishingmod:Catch", function() 
+	local entity = net.ReadInt(16)
+	local friendly = net.ReadString()
+	local caught = net.ReadInt(32)
+	local owner = net.ReadString()
+	local fried = net.ReadInt(16)
+	local value = net.ReadInt(32)
 	
 	value = value == 0 and "????" or value
 
@@ -124,9 +124,9 @@ usermessage.Hook("Fishingmod:Catch", function(um)
 	fishingmod.InfoTable.Catch[entity].text = text
 end)
 
-usermessage.Hook("Fishingmod:Bait", function(um) 
-	local entity = um:ReadShort()
-	local owner = um:ReadString()
+net.Receive("Fishingmod:Bait", function() 
+	local entity = net.ReadInt(16)
+	local owner = net.ReadString()
 	
 	local ply = game.SinglePlayer() and LocalPlayer() or player.GetByUniqueID(owner)
 	

--- a/lua/fishing_mod/sv_networking.lua
+++ b/lua/fishing_mod/sv_networking.lua
@@ -1,3 +1,8 @@
+util.AddNetworkString("Fishingmod:Catch")
+util.AddNetworkString("Fishingmod:Bait")
+util.AddNetworkString("Fishingmod:Player")
+util.AddNetworkString("Fishingmod:BaitPrices")
+
 function fishingmod.SetCatchInfo(entity, ply)
 	local rp = RecipientFilter()
 	if not ply then 
@@ -8,11 +13,11 @@ function fishingmod.SetCatchInfo(entity, ply)
 	
 	entity.data = entity.data or {}
 	
-	umsg.Start("Fishingmod:Catch", rp)
-		umsg.Short(entity:EntIndex() or 0)
-		umsg.String(entity.data.friendly or "unknown")
-		umsg.Long(entity.data.caught or 0)
-		umsg.String(
+	net.Start("Fishingmod:Catch")
+		net.WriteInt(entity:EntIndex() or 0, 16)
+		net.WriteString(entity.data.friendly or "unknown")
+		net.WriteInt(entity.data.caught or 0, 32)
+		net.WriteString(
 			entity.data.owner and (
 			type(entity.data.owner)=="string" and entity.data.owner or 
 			
@@ -20,9 +25,9 @@ function fishingmod.SetCatchInfo(entity, ply)
 				entity.data.owner:Nick()
 			) or 
 			"Unknown")
-		umsg.Short(entity.data.fried or 0)
-		umsg.Long(entity.data.value or 0)
-	umsg.End()
+		net.WriteInt(entity.data.fried or 0, 16)
+		net.WriteInt(entity.data.value or 0, 32)
+	net.Send(rp)
 end
 
 function fishingmod.SetBaitInfo(entity, ply)
@@ -35,31 +40,30 @@ function fishingmod.SetBaitInfo(entity, ply)
 	
 	entity.data = entity.data or {}
 	
-	umsg.Start("Fishingmod:Bait", rp)
-		umsg.Short(entity:EntIndex() or 0)
-		--umsg.String(entity.data.friendly or "unknown")
-		umsg.String(entity.data.ownerid or "unknown")
-	umsg.End()
+	net.Start("Fishingmod:Bait")
+		net.WriteInt(entity:EntIndex() or 0, 16)
+		net.WriteString(entity.data.ownerid or "unknown")
+	net.Send(rp)
 end
 
 function fishingmod.UpdatePlayerInfo(ply, spawned)
-	umsg.Start("Fishingmod:Player")
-		umsg.Entity(ply)
-		umsg.Long(ply.fishingmod.exp)
-		umsg.Long(ply.fishingmod.catches)
-		umsg.Long(ply.fishingmod.money)
-		umsg.Char(ply.fishingmod.length)
-		umsg.Char(ply.fishingmod.reel_speed)
-		umsg.Short(ply.fishingmod.string_length)
-		umsg.Short(ply.fishingmod.force)
-		umsg.Bool(spawned or false)
-	umsg.End()	
+	net.Start("Fishingmod:Player")
+		net.WriteEntity(ply)
+		net.WriteInt(ply.fishingmod.exp, 32)
+		net.WriteInt(ply.fishingmod.catches, 32)
+		net.WriteInt(ply.fishingmod.money, 32)
+		net.WriteInt(ply.fishingmod.length, 8)
+		net.WriteInt(ply.fishingmod.reel_speed, 8)
+		net.WriteInt(ply.fishingmod.string_length, 16)
+		net.WriteInt(ply.fishingmod.force, 16)
+		net.WriteBool(spawned or false)
+	net.Broadcast()	
 end
 
 function fishingmod.SetBaitSale(bait, multiplier, ply)
 	fishingmod.BaitTable[bait].multiplier = multiplier
-	umsg.Start("Fishingmod:BaitPrices", ply)
-		umsg.String(bait)
-		umsg.Float(multiplier)
-	umsg.End()
+	net.Start("Fishingmod:BaitPrices")
+		net.WriteString(bait)
+		net.WriteFloat(multiplier) 
+	net.Send(ply)
 end


### PR DESCRIPTION
User messages are outdated, and so is this fishing mod (jk)
Converted most user messages (if not all) to net messages. This may need some improvement as I replaced umsg.Short with WriteInt(x, 16) but I rather see that than usermessages.

On commit 5db91f4 I removed an aowl command but reverted in bbe6db2 (squash commits?)