### PR TITLE
new look is now customizable and minor behaviour fixes

### DIFF
--- a/lua/autorun/fishing_mod_init.lua
+++ b/lua/autorun/fishing_mod_init.lua
@@ -11,8 +11,10 @@ if SERVER then
 else
 
 	include("fishing_mod/cl_init.lua")
-	concommand.Add("fishing_mod_menu", function() 
-		fishingmod.UpgradeMenu = vgui.Create('Fishingmod:ShopMenu') fishingmod.UpgradeMenu:SetVisible(true) 
+	concommand.Add("fishing_mod_menu", function(ply, cmd)
+        if ply.GetFishingRod and ply:GetFishingRod() then
+    		fishingmod.UpgradeMenu = vgui.Create('Fishingmod:ShopMenu') fishingmod.UpgradeMenu:SetVisible(true) 
+        end
 	end)
 
 end

--- a/lua/entities/entity_fishing_rod/cl_init.lua
+++ b/lua/entities/entity_fishing_rod/cl_init.lua
@@ -5,12 +5,12 @@ include("shared.lua")
 
 fishingmod.ColorTable = fishingmod.LoadUIColors()
 
-local uiText = fishingmod.DefaultUIColors().uiText
-local uiTextCaught = fishingmod.DefaultUIColors().uiTextCaught
-local uiBackground = fishingmod.DefaultUIColors().uiBackground
-local xpBarForeGr = fishingmod.DefaultUIColors().xpBarForeGr
-local xpBarBackGr = fishingmod.DefaultUIColors().xpBarBackGr
-local xpBarText = fishingmod.DefaultUIColors().xpBarText
+local ui_text = fishingmod.DefaultUIColors().ui_text
+local ui_text_caught = fishingmod.DefaultUIColors().ui_text_caught
+local ui_background = fishingmod.DefaultUIColors().ui_background
+local xp_bar_fg = fishingmod.DefaultUIColors().xp_bar_fg
+local xp_bar_bg = fishingmod.DefaultUIColors().xp_bar_bg
+local xp_bar_text = fishingmod.DefaultUIColors().xp_bar_text
 
 local rope_material = Material("cable/rope")
 
@@ -45,12 +45,12 @@ end
 
 function ENT:HUDPaint()
 	if fishingmod.ColorTable then
-		uiText = fishingmod.ColorTable.uiText or uiText
-		uiTextCaught = fishingmod.ColorTable.uiTextCaught or uiTextCaught
-		uiBackground = fishingmod.ColorTable.uiBackground or uiBackground
-		xpBarForeGr = fishingmod.ColorTable.xpBarForeGr or xpBarForeGr
-		xpBarBackGr = fishingmod.ColorTable.xpBarBackGr or xpBarBackGr
-		xpBarText = fishingmod.ColorTable.xpBarText or xpBarText
+		ui_text = fishingmod.ColorTable.ui_text or ui_text
+		ui_text_caught = fishingmod.ColorTable.ui_text_caught or ui_text_caught
+		ui_background = fishingmod.ColorTable.ui_background or ui_background
+		xp_bar_fg = fishingmod.ColorTable.xp_bar_fg or xp_bar_fg
+		xp_bar_bg = fishingmod.ColorTable.xp_bar_bg or xp_bar_bg
+		xp_bar_text = fishingmod.ColorTable.xp_bar_text or xp_bar_text
 	end
 
 	local ply = self:GetPlayer()
@@ -60,21 +60,21 @@ function ENT:HUDPaint()
 		
 	local xy = ((self:GetBobber() and self:GetBobber():GetPos() or Vector()) + Vector(0,0,10)):ToScreen() -- kinda unsure about this Vec'0,0,+10'
 
-	local height_offset       = 40
-	local marginFromBorder    = 16                         -- 16 pixels from the top and bottom border of the screen/game window
-	local innerBoxXY          = 3                          -- padding of the 2 shades of background
-	local bg_heightdepthcatch = 0                          -- if a catch or depth exist elongate the box
-	local minwid              = 50                         -- minimum width of dark background box
-	local tempNick            = ply:Nick()
-	local markup              = 0
+	local height_offset = 40
+	local margin_from_border = 16         -- 16 pixels from the top and bottom border of the screen/game window
+	local inner_box_xy = 3                -- padding of the 2 shades of background
+	local bg_heightdepthcatch = 0         -- if a catch or depth exist elongate the box
+	local minwid = 50                     -- minimum width of dark background box
+	local temp_nick = ply:Nick()
+	local markup = 0
 	local stripped_name_width = 0
-	local team_col            = team.GetColor(ply:Team())
+	local team_col = team.GetColor(ply:Team())
 	if EasyChat then 
-		markup = ec_markup.AdvancedParse(tempNick, {
+		markup = ec_markup.AdvancedParse(temp_nick, {
 			nick = true,
 			default_color = team_col,
-			default_font = "fixed_NameFont",
-			default_shadow_font = "fixed_NameFont",
+			default_font = "fixed_name_font",
+			default_shadow_font = "fixed_name_font",
 		}) 
 		stripped_name_width = markup:GetWidth()
 	end
@@ -92,34 +92,34 @@ function ENT:HUDPaint()
 		bg_heightdepthcatch = bg_heightdepthcatch + 10
 	end
 
-	surface.SetFont("fixed_Height_Font")
-	local textBelow = "Total Catch: " .. ply.fishingmod.catches .. "\nMoney: " .. (math.Round(ply.fishingmod.money) or "0") .. "\nLevel: " .. ply.fishingmod.level .. "\nLength: " .. tostring(math.Round((self:GetLength() * 2.54) / 100 * 10) / 10) .. depth .. catch
-	local boxBelow_W, boxBelow_H = surface.GetTextSize(textBelow)
+	surface.SetFont("fixed_height_font")
+	local text_below = "Total Catch: " .. ply.fishingmod.catches .. "\nMoney: " .. (math.Round(ply.fishingmod.money) or "0") .. "\nLevel: " .. ply.fishingmod.level .. "\nLength: " .. tostring(math.Round((self:GetLength() * 2.54) / 100 * 10) / 10) .. depth .. catch
+	local box_below_w, box_below_h = surface.GetTextSize(text_below)
 
-	surface.SetFont("fixed_NameFont")
-	local xhypo, yhypo = surface.GetTextSize(tempNick)
+	surface.SetFont("fixed_name_font")
+	local xhypo, yhypo = surface.GetTextSize(temp_nick)
 	
-	xy.y = math.Clamp(xy.y - height_offset, 120 + height_offset + marginFromBorder, ScrH() + height_offset - marginFromBorder - bg_heightdepthcatch)
+	xy.y = math.Clamp(xy.y - height_offset, 120 + height_offset + margin_from_border, ScrH() + height_offset - margin_from_border - bg_heightdepthcatch)
 
-	local bg_x, bg_width = xy.x - math.max(minwid, xhypo / 2, boxBelow_W / 2) - 10, (math.max(minwid, xhypo / 2, boxBelow_W / 2) + 10) * 2
-	local bg_y, bg_height = xy.y - 120 - height_offset, 70 + boxBelow_H
-	local ecbg_x, ecbg_width = xy.x - math.max(minwid, stripped_name_width / 2, ( boxBelow_W / 2)) - 10, (math.max(minwid, stripped_name_width / 2, boxBelow_W / 2) + 10) * 2
+	local bg_x, bg_width = xy.x - math.max(minwid, xhypo / 2, box_below_w / 2) - 10, (math.max(minwid, xhypo / 2, box_below_w / 2) + 10) * 2
+	local bg_y, bg_height = xy.y - 120 - height_offset, 70 + box_below_h
+	local ecbg_x, ecbg_width = xy.x - math.max(minwid, stripped_name_width / 2, ( box_below_w / 2)) - 10, (math.max(minwid, stripped_name_width / 2, box_below_w / 2) + 10) * 2
 
-	surface.SetDrawColor(uiBackground.r, uiBackground.g, uiBackground.b, uiBackground.a)
+	surface.SetDrawColor(ui_background.r, ui_background.g, ui_background.b, ui_background.a)
 
 	if EasyChat then
 		surface.DrawRect(ecbg_x, bg_y, ecbg_width, bg_height)
-		surface.DrawRect(ecbg_x + innerBoxXY, bg_y + innerBoxXY, ecbg_width - (2 * innerBoxXY), bg_height - (2 * innerBoxXY))
+		surface.DrawRect(ecbg_x + inner_box_xy, bg_y + inner_box_xy, ecbg_width - (2 * inner_box_xy), bg_height - (2 * inner_box_xy))
 		markup:Draw(xy.x - (stripped_name_width / 2), xy.y - 102 - height_offset - markup:GetHeight()/2)
 	else
 		surface.DrawRect(bg_x, bg_y, bg_width, bg_height)
-		surface.DrawRect(bg_x + innerBoxXY, bg_y + innerBoxXY, bg_width - (2 * innerBoxXY), bg_height - (2 * innerBoxXY) )
-		draw.DrawText(tempNick, "fixed_NameFont", xy.x, xy.y - 112 - height_offset, team_col, 1)
+		surface.DrawRect(bg_x + inner_box_xy, bg_y + inner_box_xy, bg_width - (2 * inner_box_xy), bg_height - (2 * inner_box_xy) )
+		draw.DrawText(temp_nick, "fixed_name_font", xy.x, xy.y - 112 - height_offset, team_col, 1)
 	end
-	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, 100, 23, xpBarBackGr)
-	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, math.min(ply.fishingmod.percent, 100), 23, xpBarForeGr)
-	draw.DrawText(tostring(math.Round(ply.fishingmod.expleft)), "fixed_Height_Font" , xy.x, xy.y - 84 - height_offset, xpBarText, 1)
-	draw.DrawText(textBelow, "fixed_Height_Font", xy.x, xy.y - 60 - height_offset, hooked_entity and uiTextCaught or uiText, 1)
+	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, 100, 23, xp_bar_bg)
+	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, math.min(ply.fishingmod.percent, 100), 23, xp_bar_fg)
+	draw.DrawText(tostring(math.Round(ply.fishingmod.expleft)), "fixed_height_font" , xy.x, xy.y - 84 - height_offset, xp_bar_text, 1)
+	draw.DrawText(text_below, "fixed_height_font", xy.x, xy.y - 60 - height_offset, hooked_entity and ui_text_caught or ui_text, 1)
 end
 
 function ENT:Initialize()

--- a/lua/entities/entity_fishing_rod/cl_init.lua
+++ b/lua/entities/entity_fishing_rod/cl_init.lua
@@ -5,12 +5,12 @@ include("shared.lua")
 
 fishingmod.ColorTable = fishingmod.LoadUIColors()
 
-local uiText = fishingmod.ColorTable.uiText
-local uiTextCaught = fishingmod.ColorTable.uiTextCaught
-local uiBackground = fishingmod.ColorTable.uiBackground
-local xpBarForeGr = fishingmod.ColorTable.xpBarForeGr
-local xpBarBackGr = fishingmod.ColorTable.xpBarBackGr
-local xpBarText = fishingmod.ColorTable.xpBarText
+local uiText = fishingmod.DefaultUIColors().uiText
+local uiTextCaught = fishingmod.DefaultUIColors().uiTextCaught
+local uiBackground = fishingmod.DefaultUIColors().uiBackground
+local xpBarForeGr = fishingmod.DefaultUIColors().xpBarForeGr
+local xpBarBackGr = fishingmod.DefaultUIColors().xpBarBackGr
+local xpBarText = fishingmod.DefaultUIColors().xpBarText
 
 local rope_material = Material("cable/rope")
 
@@ -44,16 +44,13 @@ function ENT:RenderScene()
 end
 
 function ENT:HUDPaint()
-
-	if fishingmod then
-		if fishingmod.ColorTable then
-			uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
-			uiTextCaught = fishingmod.ColorTable.uiTextCaught or fishingmod.DefaultUIColors().uiTextCaught
-			uiBackground = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
-			xpBarForeGr = fishingmod.ColorTable.xpBarForeGr or fishingmod.DefaultUIColors().xpBarForeGr
-			xpBarBackGr = fishingmod.ColorTable.xpBarBackGr or fishingmod.DefaultUIColors().xpBarBackGr
-			xpBarText = fishingmod.ColorTable.xpBarText or fishingmod.DefaultUIColors().xpBarText
-		end
+	if fishingmod.ColorTable then
+		uiText = fishingmod.ColorTable.uiText or uiText
+		uiTextCaught = fishingmod.ColorTable.uiTextCaught or uiTextCaught
+		uiBackground = fishingmod.ColorTable.uiBackground or uiBackground
+		xpBarForeGr = fishingmod.ColorTable.xpBarForeGr or xpBarForeGr
+		xpBarBackGr = fishingmod.ColorTable.xpBarBackGr or xpBarBackGr
+		xpBarText = fishingmod.ColorTable.xpBarText or xpBarText
 	end
 
 	local ply = self:GetPlayer()

--- a/lua/entities/entity_fishing_rod/cl_init.lua
+++ b/lua/entities/entity_fishing_rod/cl_init.lua
@@ -2,6 +2,16 @@ language.Add("entity_fishing_rod", "Fishing Rod")
 
 include("shared.lua")
 
+
+fishingmod.ColorTable = fishingmod.LoadUIColors()
+
+local uiText = fishingmod.ColorTable.uiText
+local uiTextCaught = fishingmod.ColorTable.uiTextCaught
+local uiBackground = fishingmod.ColorTable.uiBackground
+local xpBarForeGr = fishingmod.ColorTable.xpBarForeGr
+local xpBarBackGr = fishingmod.ColorTable.xpBarBackGr
+local xpBarText = fishingmod.ColorTable.xpBarText
+
 local rope_material = Material("cable/rope")
 
 function ENT:Draw()
@@ -34,6 +44,18 @@ function ENT:RenderScene()
 end
 
 function ENT:HUDPaint()
+
+	if fishingmod then
+		if fishingmod.ColorTable then
+			uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
+			uiTextCaught = fishingmod.ColorTable.uiTextCaught or fishingmod.DefaultUIColors().uiTextCaught
+			uiBackground = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+			xpBarForeGr = fishingmod.ColorTable.xpBarForeGr or fishingmod.DefaultUIColors().xpBarForeGr
+			xpBarBackGr = fishingmod.ColorTable.xpBarBackGr or fishingmod.DefaultUIColors().xpBarBackGr
+			xpBarText = fishingmod.ColorTable.xpBarText or fishingmod.DefaultUIColors().xpBarText
+		end
+	end
+
 	local ply = self:GetPlayer()
 	
 	if not IsValid(ply) or (ply and not ply.fishingmod) then return end
@@ -74,7 +96,7 @@ function ENT:HUDPaint()
 	end
 
 	surface.SetFont("fixed_Height_Font")
-	local textBelow = "Total Catch: " .. ply.fishingmod.catches .. "\nMoney: " .. (math.Round(ply.fishingmod.money,2) or "0") .. "\nLevel: " .. ply.fishingmod.level .. "\nLength: " .. tostring(math.Round((self:GetLength() * 2.54) / 100 * 10) / 10) .. depth .. catch
+	local textBelow = "Total Catch: " .. ply.fishingmod.catches .. "\nMoney: " .. (math.Round(ply.fishingmod.money) or "0") .. "\nLevel: " .. ply.fishingmod.level .. "\nLength: " .. tostring(math.Round((self:GetLength() * 2.54) / 100 * 10) / 10) .. depth .. catch
 	local boxBelow_W, boxBelow_H = surface.GetTextSize(textBelow)
 
 	surface.SetFont("fixed_NameFont")
@@ -86,7 +108,7 @@ function ENT:HUDPaint()
 	local bg_y, bg_height = xy.y - 120 - height_offset, 70 + boxBelow_H
 	local ecbg_x, ecbg_width = xy.x - math.max(minwid, stripped_name_width / 2, ( boxBelow_W / 2)) - 10, (math.max(minwid, stripped_name_width / 2, boxBelow_W / 2) + 10) * 2
 
-	surface.SetDrawColor(0, 0, 0, 144)
+	surface.SetDrawColor(uiBackground.r, uiBackground.g, uiBackground.b, uiBackground.a)
 
 	if EasyChat then
 		surface.DrawRect(ecbg_x, bg_y, ecbg_width, bg_height)
@@ -97,10 +119,10 @@ function ENT:HUDPaint()
 		surface.DrawRect(bg_x + innerBoxXY, bg_y + innerBoxXY, bg_width - (2 * innerBoxXY), bg_height - (2 * innerBoxXY) )
 		draw.DrawText(tempNick, "fixed_NameFont", xy.x, xy.y - 112 - height_offset, team_col, 1)
 	end
-	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, 100, 23, Color(255, 255, 255, 55))
-	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, math.min(ply.fishingmod.percent, 100), 23, Color(0, 255, 0, 150))
-	draw.DrawText(tostring(math.Round(ply.fishingmod.expleft)), "fixed_Height_Font" , xy.x, xy.y - 84 - height_offset, color_black, 1)
-	draw.DrawText(textBelow, "fixed_Height_Font", xy.x, xy.y - 60 - height_offset, hooked_entity and Color(0, 255, 0, 255) or color_white,1)
+	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, 100, 23, xpBarBackGr)
+	draw.RoundedBox(1, xy.x - 50, xy.y - 88 - height_offset, math.min(ply.fishingmod.percent, 100), 23, xpBarForeGr)
+	draw.DrawText(tostring(math.Round(ply.fishingmod.expleft)), "fixed_Height_Font" , xy.x, xy.y - 84 - height_offset, xpBarText, 1)
+	draw.DrawText(textBelow, "fixed_Height_Font", xy.x, xy.y - 60 - height_offset, hooked_entity and uiTextCaught or uiText, 1)
 end
 
 function ENT:Initialize()

--- a/lua/entities/entity_fishing_rod/init.lua
+++ b/lua/entities/entity_fishing_rod/init.lua
@@ -82,8 +82,6 @@ function ENT:AssignPlayer(ply)
 	bobber:SetOwner(ply)
 	bobber:SetPos(position)
 	bobber:Spawn()
-	function bobber:CanTool() return false end
-	function bobber:CanProperty() return false end
 	hook.Run("PlayerSpawnedSENT", ply, bobber)
 	if bobber.CPPISetOwner then bobber:CPPISetOwner(ply) end
 	

--- a/lua/entities/entity_fishing_rod/init.lua
+++ b/lua/entities/entity_fishing_rod/init.lua
@@ -58,11 +58,16 @@ function ENT:SetLength(length)
 	if not IsValid(self.physical_rope) then return end
 	self.physical_rope:Fire("SetSpringLength", length/2+10)
 	local hookent = self:GetHook()
-	if IsValid(hookent) then
-		hookent.physical_rope:Fire("SetSpringLength", length/2+10)
+	if IsValid(hookent) and hookent.physical_rope then
+		if IsValid(hookent.physical_rope) then
+			hookent.physical_rope:Fire("SetSpringLength", length/2+10)
+		end
 	end
 	self.dt.length = length
 end
+
+function ENT:CanTool() return false end
+function ENT:CanProperty() return false end
 
 function ENT:AssignPlayer(ply)
 	self:SetOwner(ply)
@@ -77,6 +82,8 @@ function ENT:AssignPlayer(ply)
 	bobber:SetOwner(ply)
 	bobber:SetPos(position)
 	bobber:Spawn()
+	function bobber:CanTool() return false end
+	function bobber:CanProperty() return false end
 	hook.Run("PlayerSpawnedSENT", ply, bobber)
 	if bobber.CPPISetOwner then bobber:CPPISetOwner(ply) end
 	
@@ -87,6 +94,8 @@ function ENT:AssignPlayer(ply)
 	fish_hook:SetOwner(ply)
 	fish_hook:SetPos(position)
 	fish_hook:Spawn()
+	function fish_hook:CanTool() return false end
+	function fish_hook:CanProperty() return false end
 	hook.Run("PlayerSpawnedSENT", ply, fish_hook)
 	if fish_hook.CPPISetOwner then fish_hook:CPPISetOwner(ply) end
 	
@@ -119,5 +128,7 @@ function ENT:OnRemove()
 	SafeRemoveEntity(self.dt.attach)
 	SafeRemoveEntity(self.physical_rope)
 	SafeRemoveEntity(self.avatar)
-	SafeRemoveEntity(self.dt.attach.dt.hook)
+	if self.dt.attach.dt then
+		SafeRemoveEntity(self.dt.attach.dt.hook)
+	end
 end

--- a/lua/entities/entity_fishing_rod/init.lua
+++ b/lua/entities/entity_fishing_rod/init.lua
@@ -58,10 +58,8 @@ function ENT:SetLength(length)
 	if not IsValid(self.physical_rope) then return end
 	self.physical_rope:Fire("SetSpringLength", length/2+10)
 	local hookent = self:GetHook()
-	if IsValid(hookent) and hookent.physical_rope then
-		if IsValid(hookent.physical_rope) then
-			hookent.physical_rope:Fire("SetSpringLength", length/2+10)
-		end
+	if IsValid(hookent) and IsValid(hookent.physical_rope) then
+		hookent.physical_rope:Fire("SetSpringLength", length/2+10)
 	end
 	self.dt.length = length
 end

--- a/lua/entities/entity_fishing_rod/init.lua
+++ b/lua/entities/entity_fishing_rod/init.lua
@@ -90,8 +90,6 @@ function ENT:AssignPlayer(ply)
 	fish_hook:SetOwner(ply)
 	fish_hook:SetPos(position)
 	fish_hook:Spawn()
-	function fish_hook:CanTool() return false end
-	function fish_hook:CanProperty() return false end
 	hook.Run("PlayerSpawnedSENT", ply, fish_hook)
 	if fish_hook.CPPISetOwner then fish_hook:CPPISetOwner(ply) end
 	

--- a/lua/entities/fishing_mod_seagull/init.lua
+++ b/lua/entities/fishing_mod_seagull/init.lua
@@ -116,7 +116,8 @@ function ENT:OnTakeDamage(data)
 	local inflictor = data:GetInflictor()
 	local attacker = data:GetAttacker()
 	
-	if data:IsBulletDamage() and attacker:IsPlayer() then
+	if not self.spawnedRagdoll and data:IsBulletDamage() and attacker:IsPlayer() then
+		self.spawnedRagdoll = true
 		local ragdoll = ents.Create("prop_ragdoll")
 		ragdoll:SetModel(self:GetModel())
 		ragdoll:SetPos(self:GetPos())

--- a/lua/entities/fishing_mod_seagull/init.lua
+++ b/lua/entities/fishing_mod_seagull/init.lua
@@ -11,7 +11,7 @@ function ENT:Initialize()
 	
 	if not IsValid(self.target) then self:PickTarget() end
 	
-	self:SetupHook("EntityTakeDamage")
+	--self:SetupHook("EntityTakeDamage")
 	
 	bird = self
 	
@@ -69,7 +69,6 @@ function ENT:PhysicsSimulate(phys)
 	
 	local target = IsValid(self.target) and self.target
 	local owner = IsValid(self.owner) and self.owner
-			
 	phys:Wake()
 	phys:EnableMotion(true)
 	
@@ -82,19 +81,19 @@ function ENT:PhysicsSimulate(phys)
 	local params = {}
 	
 	if constraint.FindConstraint(self, "Weld") and IsValid(owner) then
-		params.secondstoarrive = 0.5
+		params.secondstoarrive = 0.9 -- nerf
 		
 		local trace_forward = util.QuickTrace(self:GetPos(), self:GetForward()*5000, {self, target})
 		
 		params.angle = (self:GetForward() + trace_forward.HitNormal):Angle()
-		params.pos = self:GetPos() + (self:GetForward() + trace_forward.HitNormal) * 100
-		params.dampfactor = 0.1
+		params.pos = self:GetPos() + (self:GetForward() + trace_forward.HitNormal) * 180 -- buff
+		params.dampfactor = 0.4
 	else
 		local direction = target:GetPos()-self:GetPos()
-		params.secondstoarrive = 1
-		params.pos = target:GetPos()
+		params.secondstoarrive = 0.7 -- buff
+		params.pos = target:GetPos() + target:GetVelocity()*0.1 -- buff
 		params.angle = direction:Angle()
-		params.dampfactor = 0.4
+		params.dampfactor = 0.3
 	end
 	
 	params.maxangular = 5000 
@@ -116,7 +115,7 @@ function ENT:OnTakeDamage(data)
 	local inflictor = data:GetInflictor()
 	local attacker = data:GetAttacker()
 	
-	if not self.spawnedRagdoll and data:IsBulletDamage() and attacker:IsPlayer() then
+	if not self.spawnedRagdoll and (data:IsBulletDamage() or data:IsDamageType(128)) and attacker:IsPlayer() then
 		self.spawnedRagdoll = true
 		local ragdoll = ents.Create("prop_ragdoll")
 		ragdoll:SetModel(self:GetModel())

--- a/lua/entities/fishing_rod_bobber/init.lua
+++ b/lua/entities/fishing_rod_bobber/init.lua
@@ -15,6 +15,9 @@ function ENT:Initialize()
 	end
 end
 
+function ENT:CanTool() return false end
+function ENT:CanProperty() return false end
+
 function ENT:Yank( force )
 	force = force or math.random( 50, 100 )
 	self:GetPhysicsObject():AddVelocity( Vector( 0, 0, -force ) )

--- a/lua/entities/fishing_rod_hook/init.lua
+++ b/lua/entities/fishing_rod_hook/init.lua
@@ -199,6 +199,9 @@ function ENT:UnHook()
 	end
 end
 
+function ENT:CanTool() return false end
+function ENT:CanProperty() return false end
+
 function ENT:OnRemove()
 	if IsValid(self.dt.hooked) then
 		self.dt.hooked:SetParent()

--- a/lua/entities/fishing_rod_hook/init.lua
+++ b/lua/entities/fishing_rod_hook/init.lua
@@ -214,6 +214,7 @@ function ENT:OnRemove()
 end
 
 function ENT:Think()
+    if not IsValid(self.bobber) and IsValid(self) then self:Remove() end
 	for key, entity in pairs(ents.FindInSphere(self:GetPos(), 20)) do
 		if entity.is_recatchable and not self.just_released and not entity.just_unhooked then
 			self:Hook(entity, entity.data)

--- a/lua/fishing_mod/catch/cores.lua
+++ b/lua/fishing_mod/catch/cores.lua
@@ -24,7 +24,7 @@ function ENT:SetupDataTables()
 end
 
 if SERVER then
-	
+	local col_invisible = Color(0,0,0,0)
 	function ENT:Initialize()
 		
 		self:SetModel("models/props_bts/glados_ball_reference.mdl")
@@ -32,7 +32,7 @@ if SERVER then
 		self:SetMoveType(MOVETYPE_VPHYSICS)
 		self:SetSolid(SOLID_VPHYSICS)
 		self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE)
-		self:SetColor(0,0,0,0)
+		self:SetColor(col_invisible)
 		
 		self.dt.Core = math.random(0,3)
 		
@@ -53,13 +53,15 @@ if SERVER then
 	end
 	
 	function ENT:Think()
-		self.body:ResetSequence(self.Anim)
+		if self and IsValid(self.body) then
+            self.body:ResetSequence(self.Anim)
+        end
 	end
 	
 	function ENT:OnRemove()
-		
-		self.body:Remove()
-		
+		if self and IsValid(self.body) then
+		    self.body:Remove()
+        end
 	end
 	
 else
@@ -115,7 +117,7 @@ else
 	function ENT:Draw()
 		
 		self:DrawShadow(false)
-		self:SetColor(0,0,0,0)
+		self:SetColor(col_invisible)
 		
 	end
 	

--- a/lua/fishing_mod/catch/money.lua
+++ b/lua/fishing_mod/catch/money.lua
@@ -50,7 +50,7 @@ fishingmod.AddCatch{
 	remove_on_release = false,
 	bait = {
 		"models/props_c17/cashregister01a.mdl",
-		"models/props_misc/cash_register.mdl",
+		--"models/props_misc/cash_register.mdl", -- broken bait model
 	}
 }
 

--- a/lua/fishing_mod/catch/prospecting.lua
+++ b/lua/fishing_mod/catch/prospecting.lua
@@ -79,7 +79,7 @@ ENT.Type = "anim"
 ENT.Base = "fishing_mod_base"
 
 if SERVER then
-	
+	local col_bronze = Color(184, 115, 51, 255)
 	function ENT:Initialize()
 		self:SetModel("models/props_mining/ingot001.mdl")
 		self:SetMoveType( MOVETYPE_VPHYSICS )
@@ -87,7 +87,7 @@ if SERVER then
 		self:PhysicsInit(SOLID_VPHYSICS)
 		self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE)
 		
-		self:SetColor(Color(184, 115, 51, 255))
+		self:SetColor(col_bronze)
 
 	end
 	
@@ -177,7 +177,7 @@ ENT.Type = "anim"
 ENT.Base = "fishing_mod_base"
 
 if SERVER then
-	
+	local color_gray = Color(100, 100, 100, 255)
 	function ENT:Initialize()
 		self:SetModel("models/props_mining/ingot001.mdl")
 		self:SetMoveType( MOVETYPE_VPHYSICS )
@@ -186,7 +186,7 @@ if SERVER then
 		self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE)
 		
 		self:SetMaterial("models/shiny")
-		self:SetColor(100, 100, 100, 255)
+		self:SetColor(color_gray)
 
 	end
 	
@@ -227,7 +227,7 @@ ENT.Type = "anim"
 ENT.Base = "fishing_mod_base"
 
 if SERVER then
-	
+	local col_silver = Color(164, 164, 164, 255)
 	function ENT:Initialize()
 		self.ThinkNext = 0
 		self:SetModel("models/props_mining/ingot001.mdl")
@@ -237,7 +237,7 @@ if SERVER then
 		self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE)
 		
 		self:SetMaterial("models/shiny")
-		self:SetColor(Color(164, 164, 164, 255))
+		self:SetColor(col_silver)
 
 	end
 	
@@ -467,7 +467,7 @@ if SERVER then
 		self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE)
 		
 		self:SetMaterial("models/shiny")
-		self:SetColor(Color(164, 164, 164, 255))
+		self:SetColor(col_silver)
 		
 	end
 	

--- a/lua/fishing_mod/catch/stove.lua
+++ b/lua/fishing_mod/catch/stove.lua
@@ -12,6 +12,8 @@ fishingmod.AddCatch{
 	levelrequired = 5,
 	bait = {"models/props_c17/metalPot002a.mdl"}
 }
+
+local margin = 3
 local color_white = color_white or Color(255, 255, 255, 255)
 local ENT = {}
 
@@ -137,13 +139,13 @@ if CLIENT then
 	end
 
 	function ENT:ShowHeatAdjuster()
-		local back_ground = fishingmod.DefaultUIColors().ui_background
+		local background = fishingmod.DefaultUIColors().ui_background
 		local button_not_selected = fishingmod.DefaultUIColors().ui_button_deselected
 		local ui_button_selected = fishingmod.DefaultUIColors().ui_button_selected
 		local ui_button_hovered = fishingmod.DefaultUIColors().ui_button_hovered
 		local ui_text = fishingmod.DefaultUIColors().ui_text
 		if fishingmod.ColorTable then
-			back_ground = fishingmod.ColorTable.ui_background or back_ground
+			background = fishingmod.ColorTable.ui_background or background
 			button_not_selected = fishingmod.ColorTable.ui_button_deselected or button_not_selected
 			ui_button_selected = fishingmod.ColorTable.ui_button_selected or ui_button_selected
 			ui_button_hovered = fishingmod.ColorTable.ui_button_hovered or ui_button_hovered
@@ -154,35 +156,35 @@ if CLIENT then
 		local frame = vgui.Create("DFrame")
 		frame.Paint = function(s, x, y)
 			
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 			surface.DrawRect(0, 0, x, y)
-			surface.DrawRect(3, 24, x - 6, y - 24 - 3)
+			surface.DrawRect(margin, 24, x - margin * 2, y - 24 - margin)
 		end
-		frame:ShowCloseButton(false)
-		local closebutton = vgui.Create("DButton", frame)
+		frame:Showclose_button(false)
+		local close_button = vgui.Create("DButton", frame)
 		local x, y = frame:GetSize()
-		closebutton.ButtonW = 60
-		closebutton:SetSize(closebutton.ButtonW, 18)
-		closebutton:SetText("Close")
-		closebutton:SetTextColor(ui_text)
-		closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
-		closebutton.DoClick = function()
+		close_button.ButtonW = 60
+		close_button:SetSize(close_button.ButtonW, 18)
+		close_button:SetText("Close")
+		close_button:SetTextColor(ui_text)
+		close_button:SetPos(x - close_button.ButtonW - margin, margin)
+		close_button.DoClick = function()
 			frame:Close()
 		end
-		closebutton.Paint = function(self, w, h)
+		close_button.Paint = function(self, w, h)
 			
-			if(closebutton:IsDown() ) then
+			if(close_button:IsDown() ) then
 				surface.SetDrawColor(button_not_selected.r, button_not_selected.g, button_not_selected.b, button_not_selected.a)
-			elseif(closebutton:IsHovered()) then
+			elseif(close_button:IsHovered()) then
 				surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 			else
-				surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+				surface.SetDrawColor(background.r, background.g, background.b, background.a)
 			end
 			surface.DrawRect(0, 0, w, h)
 		end
 		function frame:OnSizeChanged(x, y)
-			closebutton:SetPos(math.max(x - closebutton.ButtonW - 3, 3), 3)
-			closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
+			close_button:SetPos(math.max(x - close_button.ButtonW - margin, margin), margin)
+			close_button:SetSize(math.min(close_button.ButtonW, x - margin * 2) , 18 )
 		end
 		frame:SetSize(300, 80)
 		frame.lblTitle:SetTextColor(ui_text)

--- a/lua/fishing_mod/catch/stove.lua
+++ b/lua/fishing_mod/catch/stove.lua
@@ -34,19 +34,6 @@ function ENT:SetupDataTables()
 end
 
 if CLIENT then
-	if fishingmod then
-		if fishingmod.ColorTable then
-			uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
-			bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
-			sel = fishingmod.ColorTable.uiButtonSelected or fishingmod.ColorTable.uiButtonSelected
-			nosel = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
-			hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
-			pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
-		else
-			fishingmod.ColorTable = fishingmod.DefaultUIColors()
-		end
-	end
-
 	local sprite = Material( "sprites/splodesprite" )
 	function ENT:Initialize()
 		self.emitter = ParticleEmitter(self:GetPos())
@@ -148,25 +135,28 @@ if CLIENT then
 			render.DrawSprite( self:GetPos() + ( self:GetUp() * v.position.z ) + ( self:GetRight() * v.position.x ) + ( self:GetForward() * v.position.y ), 1, 1, Color( 255, 255, 255, 255 ) )
 		end
 	end
-		
+
 	function ENT:ShowHeatAdjuster()
+		local bg = fishingmod.DefaultUIColors().uiBackground
+		local nosel = fishingmod.DefaultUIColors().uiButtonDeSelected
+		local sel = fishingmod.DefaultUIColors().uiButtonSelected
+		local hov = fishingmod.DefaultUIColors().uiButtonHovered
+		local uiText = fishingmod.DefaultUIColors().uiText
+		if fishingmod.ColorTable then
+			bg = fishingmod.ColorTable.uiBackground or bg
+			nosel = fishingmod.ColorTable.uiButtonDeSelected or nosel
+			sel = fishingmod.ColorTable.uiButtonSelected or sel
+			hov = fishingmod.ColorTable.uiButtonHovered or hov
+			uiText = fishingmod.ColorTable.uiText or uiText
+		else
+			fishingmod.ColorTable = fishingmod.DefaultUIColors()
+		end
 		local frame = vgui.Create("DFrame")
 		frame.Paint = function(s, x, y)
+			
 			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 			surface.DrawRect(0, 0, x, y)
 			surface.DrawRect(3, 24, x - 6, y - 24 - 3)
-			if fishingmod then
-				if fishingmod.ColorTable then
-					uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
-					bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
-					sel = fishingmod.ColorTable.uiButtonSelected or fishingmod.ColorTable.uiButtonSelected
-					nosel = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
-					hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
-					pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
-				else
-					fishingmod.ColorTable = fishingmod.DefaultUIColors()
-				end
-			end
 		end
 		frame:ShowCloseButton(false)
 		local closebutton = vgui.Create("DButton", frame)
@@ -180,6 +170,7 @@ if CLIENT then
 			frame:Close()
 		end
 		closebutton.Paint = function(self, w, h)
+			
 			if(closebutton:IsDown() ) then
 				surface.SetDrawColor(nosel.r, nosel.g, nosel.b, nosel.a)
 			elseif(closebutton:IsHovered()) then
@@ -194,7 +185,7 @@ if CLIENT then
 			closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
 		end
 		frame:SetSize(300, 80)
-		frame:GetTable().lblTitle:SetTextColor(uiText)
+		frame.lblTitle:SetTextColor(uiText)
 		frame:Center()
 		local p = LocalPlayer()
 
@@ -208,8 +199,8 @@ if CLIENT then
 		slider:SetMax(100)
 		slider:SetText("Heat")
 		slider:SetConVar("fishingmod_stove_heat")
-		slider:GetTable().Label:SetTextColor(uiText)
-		slider:GetTable().Wang.m_Skin.colTextEntryText = uiText
+		slider.Label:SetTextColor(uiText)
+		slider.Wang.m_Skin.colTextEntryText = uiText
 	end
 	
 	

--- a/lua/fishing_mod/catch/stove.lua
+++ b/lua/fishing_mod/catch/stove.lua
@@ -137,24 +137,24 @@ if CLIENT then
 	end
 
 	function ENT:ShowHeatAdjuster()
-		local backGround = fishingmod.DefaultUIColors().uiBackground
-		local buttonNotSelected = fishingmod.DefaultUIColors().uiButtonDeSelected
-		local uiButtonSelected = fishingmod.DefaultUIColors().uiButtonSelected
-		local uiButtonHovered = fishingmod.DefaultUIColors().uiButtonHovered
-		local uiText = fishingmod.DefaultUIColors().uiText
+		local back_ground = fishingmod.DefaultUIColors().ui_background
+		local button_not_selected = fishingmod.DefaultUIColors().ui_button_deselected
+		local ui_button_selected = fishingmod.DefaultUIColors().ui_button_selected
+		local ui_button_hovered = fishingmod.DefaultUIColors().ui_button_hovered
+		local ui_text = fishingmod.DefaultUIColors().ui_text
 		if fishingmod.ColorTable then
-			backGround = fishingmod.ColorTable.uiBackground or backGround
-			buttonNotSelected = fishingmod.ColorTable.uiButtonDeSelected or buttonNotSelected
-			uiButtonSelected = fishingmod.ColorTable.uiButtonSelected or uiButtonSelected
-			uiButtonHovered = fishingmod.ColorTable.uiButtonHovered or uiButtonHovered
-			uiText = fishingmod.ColorTable.uiText or uiText
+			back_ground = fishingmod.ColorTable.ui_background or back_ground
+			button_not_selected = fishingmod.ColorTable.ui_button_deselected or button_not_selected
+			ui_button_selected = fishingmod.ColorTable.ui_button_selected or ui_button_selected
+			ui_button_hovered = fishingmod.ColorTable.ui_button_hovered or ui_button_hovered
+			ui_text = fishingmod.ColorTable.ui_text or ui_text
 		else
 			fishingmod.ColorTable = fishingmod.DefaultUIColors()
 		end
 		local frame = vgui.Create("DFrame")
 		frame.Paint = function(s, x, y)
 			
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 			surface.DrawRect(0, 0, x, y)
 			surface.DrawRect(3, 24, x - 6, y - 24 - 3)
 		end
@@ -164,7 +164,7 @@ if CLIENT then
 		closebutton.ButtonW = 60
 		closebutton:SetSize(closebutton.ButtonW, 18)
 		closebutton:SetText("Close")
-		closebutton:SetTextColor(uiText)
+		closebutton:SetTextColor(ui_text)
 		closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
 		closebutton.DoClick = function()
 			frame:Close()
@@ -172,11 +172,11 @@ if CLIENT then
 		closebutton.Paint = function(self, w, h)
 			
 			if(closebutton:IsDown() ) then
-				surface.SetDrawColor(buttonNotSelected.r, buttonNotSelected.g, buttonNotSelected.b, buttonNotSelected.a)
+				surface.SetDrawColor(button_not_selected.r, button_not_selected.g, button_not_selected.b, button_not_selected.a)
 			elseif(closebutton:IsHovered()) then
-				surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+				surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 			else
-				surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+				surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 			end
 			surface.DrawRect(0, 0, w, h)
 		end
@@ -185,7 +185,7 @@ if CLIENT then
 			closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
 		end
 		frame:SetSize(300, 80)
-		frame.lblTitle:SetTextColor(uiText)
+		frame.lblTitle:SetTextColor(ui_text)
 		frame:Center()
 		local p = LocalPlayer()
 
@@ -199,8 +199,8 @@ if CLIENT then
 		slider:SetMax(100)
 		slider:SetText("Heat")
 		slider:SetConVar("fishingmod_stove_heat")
-		slider.Label:SetTextColor(uiText)
-		slider.Wang.m_Skin.colTextEntryText = uiText
+		slider.Label:SetTextColor(ui_text)
+		slider.Wang.m_Skin.colTextEntryText = ui_text
 	end
 	
 	

--- a/lua/fishing_mod/catch/stove.lua
+++ b/lua/fishing_mod/catch/stove.lua
@@ -137,16 +137,16 @@ if CLIENT then
 	end
 
 	function ENT:ShowHeatAdjuster()
-		local bg = fishingmod.DefaultUIColors().uiBackground
-		local nosel = fishingmod.DefaultUIColors().uiButtonDeSelected
-		local sel = fishingmod.DefaultUIColors().uiButtonSelected
-		local hov = fishingmod.DefaultUIColors().uiButtonHovered
+		local backGround = fishingmod.DefaultUIColors().uiBackground
+		local buttonNotSelected = fishingmod.DefaultUIColors().uiButtonDeSelected
+		local uiButtonSelected = fishingmod.DefaultUIColors().uiButtonSelected
+		local uiButtonHovered = fishingmod.DefaultUIColors().uiButtonHovered
 		local uiText = fishingmod.DefaultUIColors().uiText
 		if fishingmod.ColorTable then
-			bg = fishingmod.ColorTable.uiBackground or bg
-			nosel = fishingmod.ColorTable.uiButtonDeSelected or nosel
-			sel = fishingmod.ColorTable.uiButtonSelected or sel
-			hov = fishingmod.ColorTable.uiButtonHovered or hov
+			backGround = fishingmod.ColorTable.uiBackground or backGround
+			buttonNotSelected = fishingmod.ColorTable.uiButtonDeSelected or buttonNotSelected
+			uiButtonSelected = fishingmod.ColorTable.uiButtonSelected or uiButtonSelected
+			uiButtonHovered = fishingmod.ColorTable.uiButtonHovered or uiButtonHovered
 			uiText = fishingmod.ColorTable.uiText or uiText
 		else
 			fishingmod.ColorTable = fishingmod.DefaultUIColors()
@@ -154,7 +154,7 @@ if CLIENT then
 		local frame = vgui.Create("DFrame")
 		frame.Paint = function(s, x, y)
 			
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 			surface.DrawRect(0, 0, x, y)
 			surface.DrawRect(3, 24, x - 6, y - 24 - 3)
 		end
@@ -172,11 +172,11 @@ if CLIENT then
 		closebutton.Paint = function(self, w, h)
 			
 			if(closebutton:IsDown() ) then
-				surface.SetDrawColor(nosel.r, nosel.g, nosel.b, nosel.a)
+				surface.SetDrawColor(buttonNotSelected.r, buttonNotSelected.g, buttonNotSelected.b, buttonNotSelected.a)
 			elseif(closebutton:IsHovered()) then
-				surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+				surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 			else
-				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+				surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 			end
 			surface.DrawRect(0, 0, w, h)
 		end
@@ -289,7 +289,7 @@ else
 	
 		if (self.next_search or 0) < CurTime() then
 		
-			for key, entity in pairs( ents.FindInBox( self:GetPos() + self:OBBMins(), self:GetPos() + Vector(self:OBBMaxs().x, self:OBBMaxs().y, self:OBBMaxs().z * 1.2 ) ) ) do
+			for key, entity in pairs( ents.FindInBox( self:GetPos() + self:OBBMins(), self:GetPos() + self:OBBMaxs() * Vector(1, 1, 1.2) ) ) do
 				if entity.data and entity ~= self and not entity.shelf_stored and entity:GetClass() ~= "fishing_mod_catch_stove" and not entity.is_bait then
 					self:AddItem( entity )
 				end

--- a/lua/fishing_mod/catch/stove.lua
+++ b/lua/fishing_mod/catch/stove.lua
@@ -160,7 +160,7 @@ if CLIENT then
 			surface.DrawRect(0, 0, x, y)
 			surface.DrawRect(margin, 24, x - margin * 2, y - 24 - margin)
 		end
-		frame:Showclose_button(false)
+		frame:ShowCloseButton(false)
 		local close_button = vgui.Create("DButton", frame)
 		local x, y = frame:GetSize()
 		close_button.ButtonW = 60

--- a/lua/fishing_mod/catch/stove.lua
+++ b/lua/fishing_mod/catch/stove.lua
@@ -1,3 +1,4 @@
+
 fishingmod.AddCatch{
 	friendly = "Stove",
 	type = "fishing_mod_catch_stove",
@@ -33,9 +34,20 @@ function ENT:SetupDataTables()
 end
 
 if CLIENT then
+	if fishingmod then
+		if fishingmod.ColorTable then
+			uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
+			bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+			sel = fishingmod.ColorTable.uiButtonSelected or fishingmod.ColorTable.uiButtonSelected
+			nosel = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
+			hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
+			pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
+		else
+			fishingmod.ColorTable = fishingmod.DefaultUIColors()
+		end
+	end
 
 	local sprite = Material( "sprites/splodesprite" )
-	
 	function ENT:Initialize()
 		self.emitter = ParticleEmitter(self:GetPos())
 		self.sound = CreateSound(self, "ambient/fire/fire_small_loop2.wav")
@@ -140,9 +152,21 @@ if CLIENT then
 	function ENT:ShowHeatAdjuster()
 		local frame = vgui.Create("DFrame")
 		frame.Paint = function(s, x, y)
-			surface.SetDrawColor(0, 0, 0, 144)
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 			surface.DrawRect(0, 0, x, y)
-			surface.DrawRect(3, 24, x-6, y-24-3)
+			surface.DrawRect(3, 24, x - 6, y - 24 - 3)
+			if fishingmod then
+				if fishingmod.ColorTable then
+					uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
+					bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+					sel = fishingmod.ColorTable.uiButtonSelected or fishingmod.ColorTable.uiButtonSelected
+					nosel = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
+					hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
+					pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
+				else
+					fishingmod.ColorTable = fishingmod.DefaultUIColors()
+				end
+			end
 		end
 		frame:ShowCloseButton(false)
 		local closebutton = vgui.Create("DButton", frame)
@@ -150,18 +174,18 @@ if CLIENT then
 		closebutton.ButtonW = 60
 		closebutton:SetSize(closebutton.ButtonW, 18)
 		closebutton:SetText("Close")
-		closebutton:SetTextColor(color_white)
+		closebutton:SetTextColor(uiText)
 		closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
 		closebutton.DoClick = function()
 			frame:Close()
 		end
 		closebutton.Paint = function(self, w, h)
 			if(closebutton:IsDown() ) then
-				surface.SetDrawColor(0, 0, 0, 72)
+				surface.SetDrawColor(nosel.r, nosel.g, nosel.b, nosel.a)
 			elseif(closebutton:IsHovered()) then
-				surface.SetDrawColor(155, 155, 155, 144)
+				surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
 			else
-				surface.SetDrawColor(0, 0, 0, 144)
+				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 			end
 			surface.DrawRect(0, 0, w, h)
 		end
@@ -170,7 +194,7 @@ if CLIENT then
 			closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
 		end
 		frame:SetSize(300, 80)
-		frame:GetTable().lblTitle:SetTextColor(color_white)
+		frame:GetTable().lblTitle:SetTextColor(uiText)
 		frame:Center()
 		local p = LocalPlayer()
 
@@ -184,8 +208,8 @@ if CLIENT then
 		slider:SetMax(100)
 		slider:SetText("Heat")
 		slider:SetConVar("fishingmod_stove_heat")
-		slider:GetTable().Label:SetTextColor(color_white)
-		slider:GetTable().Wang.m_Skin.colTextEntryText = color_white
+		slider:GetTable().Label:SetTextColor(uiText)
+		slider:GetTable().Wang.m_Skin.colTextEntryText = uiText
 	end
 	
 	
@@ -234,7 +258,7 @@ else
 		
 		self.smoothheat = self.smoothheat + ((heat - self.smoothheat) / 1000)
 		
-		self.dt.heat = self.smoothheat * -1 +100
+		self.dt.heat = self.smoothheat * -1 + 100
 		
 		for key, data in pairs(self.storage) do
 		
@@ -251,7 +275,7 @@ else
 				if catch:IsOnFire() then catch.data.fried = 1000 end
 								
 				catch.data.fried = catch.data.fried or 0
-				catch.data.fried = math.Clamp(catch.data.fried + (catch.data.fried*self.dt.heat/700), 1, 1000)
+				catch.data.fried = math.Clamp(catch.data.fried + (catch.data.fried * self.dt.heat / 700), 1, 1000)
 				
 --[[ 				if (lastprint or 0) < CurTime() then 
 					print(catch.data.fried, self.smoothheat)
@@ -274,7 +298,7 @@ else
 	
 		if (self.next_search or 0) < CurTime() then
 		
-			for key, entity in pairs( ents.FindInBox( self:GetPos() + self:OBBMins(), self:GetPos() + self:OBBMaxs() ) ) do
+			for key, entity in pairs( ents.FindInBox( self:GetPos() + self:OBBMins(), self:GetPos() + Vector(self:OBBMaxs().x, self:OBBMaxs().y, self:OBBMaxs().z * 1.2 ) ) ) do
 				if entity.data and entity ~= self and not entity.shelf_stored and entity:GetClass() ~= "fishing_mod_catch_stove" and not entity.is_bait then
 					self:AddItem( entity )
 				end

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -7,7 +7,7 @@ surface.CreateFont("fixed_height_font", {
 	extended = false,
 	size = 13,
 	weight = 3000,
-	blursize = 0,g
+	blursize = 0,
 	scanlines = 0,
 	antialias = true,
 	underline = false,

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -2,7 +2,7 @@ fishingmod = fishingmod or {}
 
 local color_white = color_white or Color(255, 255, 255, 255)
 
-surface.CreateFont("fixed_Height_Font", {
+surface.CreateFont("fixed_height_font", {
 	font = "Verdana",
 	extended = false,
 	size = 13,
@@ -19,7 +19,7 @@ surface.CreateFont("fixed_Height_Font", {
 	additive = false,
 	outline = false,
 })
-surface.CreateFont("fixed_NameFont", {
+surface.CreateFont("fixed_name_font", {
 	font = "Verdana",
 	extended = false,
 	size = 15,
@@ -78,20 +78,20 @@ hook.Add("InitPostEntity", "Init Fish Mod", function()
 	end
 
 end)
-local uiText = fishingmod.DefaultUIColors().uiText
-local bg = fishingmod.DefaultUIColors().uiBackground
-local crosshair = fishingmod.DefaultUIColors().crossHairColor
+local ui_text = fishingmod.DefaultUIColors().ui_text
+local bg = fishingmod.DefaultUIColors().ui_background
+local crosshair = fishingmod.DefaultUIColors().crosshair_color
 hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 	local entity = LocalPlayer():GetEyeTrace().Entity
 	if fishingmod.ColorTable then 
-		crosshair = fishingmod.ColorTable.crossHairColor or fishingmod.DefaultUIColors().crossHairColor
-		uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
-		bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+		crosshair = fishingmod.ColorTable.crosshair_color or fishingmod.DefaultUIColors().crosshair_color
+		ui_text = fishingmod.ColorTable.ui_text or fishingmod.DefaultUIColors().ui_text
+		bg = fishingmod.ColorTable.ui_background or fishingmod.DefaultUIColors().ui_background
 	end
 	entity = IsValid(entity) and IsValid(entity:GetNWEntity("FMRedirect")) and entity:GetNWEntity("FMRedirect") or entity
 	if IsValid(entity) then
 		local xy = (entity:LocalToWorld(entity:OBBCenter())):ToScreen()
-		local textHeight, textWidth = 0, 0
+		local text_height, text_width = 0, 0
 		xy.y = math.min(math.max(64, xy.y), ScrH() - 64)
 		local pad = 3
 			
@@ -99,25 +99,25 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 			local data = fishingmod.InfoTable.Catch[entity:EntIndex()]
 			if data and data.text then
 				data.text = string.Replace(string.Replace(data.text, "\t", ""), "  ", " ")
-				surface.SetFont("fixed_Height_Font")
-				surface.SetDrawColor(uiText.r, uiText.g, uiText.b, uiText.a)
-				textHeight, textWidth = surface.GetTextSize(data.text)
-				textHeight, textWidth = textHeight + 8, textWidth + 8
+				surface.SetFont("fixed_height_font")
+				surface.SetDrawColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
+				text_height, text_width = surface.GetTextSize(data.text)
+				text_height, text_width = text_height + 8, text_width + 8
 				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-				surface.DrawRect(xy.x - textHeight / 2 - pad, xy.y - textWidth / 2 - 1 - pad, textHeight + pad * 2, textWidth + pad * 2)
-				surface.DrawRect(xy.x - textHeight / 2 + 3 - pad, xy.y - textWidth / 2 - 1 + 3 - pad, textHeight - 6 + pad * 2, textWidth - 6 + pad * 2)
-				draw.DrawText(data.text, "fixed_Height_Font", xy.x, xy.y - (textWidth / 2), uiText, 1) -- \t key causes it to snap
+				surface.DrawRect(xy.x - text_height / 2 - pad, xy.y - text_width / 2 - 1 - pad, text_height + pad * 2, text_width + pad * 2)
+				surface.DrawRect(xy.x - text_height / 2 + 3 - pad, xy.y - text_width / 2 - 1 + 3 - pad, text_height - 6 + pad * 2, text_width - 6 + pad * 2)
+				draw.DrawText(data.text, "fixed_height_font", xy.x, xy.y - (text_width / 2), ui_text, 1) -- \t key causes it to snap
 			end
 				
 			data = fishingmod.InfoTable.Bait[entity:EntIndex()]
 			if data and data.text then
-				surface.SetFont("fixed_Height_Font")
+				surface.SetFont("fixed_height_font")
 				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-				textHeight, textWidth = surface.GetTextSize(string.Replace(string.Replace(data.text, "\t", ""), "\n", ""))
-				textHeight, textWidth = textHeight + 8, textWidth + 8
-				surface.DrawRect(xy.x - textHeight / 2 - pad, xy.y - textWidth / 2 - 1 - pad + 16, textHeight + pad * 2, textWidth + pad * 1)
-				surface.DrawRect(xy.x - textHeight / 2 + 3 - pad, xy.y - textWidth / 2 + 2 - pad + 16, textHeight - 6 + pad * 2, textWidth - 6 + pad * 1)
-				draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (textWidth / 2) + 15, uiText, 1)
+				text_height, text_width = surface.GetTextSize(string.Replace(string.Replace(data.text, "\t", ""), "\n", ""))
+				text_height, text_width = text_height + 8, text_width + 8
+				surface.DrawRect(xy.x - text_height / 2 - pad, xy.y - text_width / 2 - 1 - pad + 16, text_height + pad * 2, text_width + pad * 1)
+				surface.DrawRect(xy.x - text_height / 2 + 3 - pad, xy.y - text_width / 2 + 2 - pad + 16, text_height - 6 + pad * 2, text_width - 6 + pad * 1)
+				draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_height_font", xy.x, xy.y - (text_width / 2) + 15, ui_text, 1)
 			end
 		end
 	end

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -7,7 +7,7 @@ surface.CreateFont("fixed_height_font", {
 	extended = false,
 	size = 13,
 	weight = 3000,
-	blursize = 0,
+	blursize = 0,g
 	scanlines = 0,
 	antialias = true,
 	underline = false,
@@ -115,8 +115,8 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 				text_height, text_width = surface.GetTextSize(string.Replace(string.Replace(data.text, "\t", ""), "\n", ""))
 				text_height, text_width = text_height + 8, text_width + 8
-				surface.DrawRect(xy.x - text_height / 2 - pad, xy.y - text_width / 2 - 1 - pad + 16, text_height + pad * 2, text_width + pad * 1)
-				surface.DrawRect(xy.x - text_height / 2 + 3 - pad, xy.y - text_width / 2 + 2 - pad + 16, text_height - 6 + pad * 2, text_width - 6 + pad * 1)
+				surface.DrawRect(xy.x - text_height / 2 - pad, xy.y - text_width / 2 - 1 - pad + 16, text_height + pad * 2, text_width + pad)
+				surface.DrawRect(xy.x - text_height / 2 + 3 - pad, xy.y - text_width / 2 + 2 - pad + 16, text_height - 6 + pad * 2, text_width - 6 + pad)
 				draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_height_font", xy.x, xy.y - (text_width / 2) + 15, ui_text, 1)
 			end
 		end
@@ -125,17 +125,17 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 	if IsValid(LocalPlayer():GetActiveWeapon()) and LocalPlayer():GetActiveWeapon():GetClass() == "weapon_fishing_rod" then
 		surface.SetDrawColor(crosshair.r, crosshair.g, crosshair.b, crosshair.a)
 		local xy = chpos:ToScreen()
-		surface.DrawRect( xy.x, xy.y+5, 1, 10)
-		surface.DrawRect( xy.x, xy.y-14, 1, 10)
+		surface.DrawRect( xy.x, xy.y + 5, 1, 10)
+		surface.DrawRect( xy.x, xy.y - 14, 1, 10)
 
-		surface.DrawRect( xy.x+5, xy.y, 10, 1 )
-		surface.DrawRect( xy.x-14, xy.y, 10, 1 )
+		surface.DrawRect( xy.x + 5, xy.y, 10, 1 )
+		surface.DrawRect( xy.x - 14, xy.y, 10, 1 )
 	end
 end)
 local force_b = 1
 concommand.Add("fishing_mod_b_opens_always", function(ply, cmd, args)
 	if isnumber(tonumber(args[1])) then
-		force_b = math.Clamp(math.Round(args[1]),0,1)
+		force_b = math.Clamp(math.Round(args[1]), 0, 1)
 	end
 end)
 hook.Add("Think", "Fishingmod.Keys:Think", function()

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -136,30 +136,28 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 		surface.DrawRect( xy.x - 14, xy.y, 10, 1 )
 	end
 end)
-local force_b = 1
-concommand.Add("fishing_mod_b_opens_always", function(ply, cmd, args)
-	if isnumber(tonumber(args[1])) then
-		force_b = math.Clamp(math.Round(tonumber(args[1])), 0, 1)
-	end
-end)
+local force_b = CreateClientConVar("fishing_mod_b_opens_always", "0")
 local ply = LocalPlayer()
 hook.Add("Think", "Fishingmod.Keys:Think", function()
-	ply = IsValid(LocalPlayer()) and ply or LocalPlayer()
-	if ply.GetFishingRod and ply:GetFishingRod() and not vgui.CursorVisible() then
-		if input.IsKeyDown(KEY_B) and force_b == 1 then
-			local menu = fishingmod.UpgradeMenu
-			if ValidPanel(menu) and not menu:IsVisible() then
-				menu:SetVisible(true)
-				menu:MakePopup()
-			end
-		end	
-		if input.IsKeyDown(KEY_E) then
-			RunConsoleCommand("fishing_mod_drop_bait")
-		end
-		if input.IsKeyDown(KEY_R) then
-			RunConsoleCommand("fishing_mod_drop_catch")
-		end	
-	end
+	if ply.GetFishingRod and ply:GetFishingRod() then
+        if not vgui.CursorVisible() then
+            if input.IsKeyDown(KEY_B) and force_b:GetInt() == 1 then
+                local menu = fishingmod.UpgradeMenu
+                if ValidPanel(menu) and not menu:IsVisible() then
+                    menu:SetVisible(true)
+                    menu:MakePopup()
+                end
+            end	
+            if input.IsKeyDown(KEY_E) then
+                RunConsoleCommand("fishing_mod_drop_bait")
+            end
+            if input.IsKeyDown(KEY_R) then
+                RunConsoleCommand("fishing_mod_drop_catch")
+            end
+        end
+	else
+        ply = LocalPlayer()
+    end
 end)
 
 hook.Add("ShouldDrawLocalPlayer", "Fishingmod:ShouldDrawLocalPlayer", function(ply)

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -91,48 +91,45 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 	entity = IsValid(entity) and IsValid(entity:GetNWEntity("FMRedirect")) and entity:GetNWEntity("FMRedirect") or entity
 	if IsValid(entity) then
 		local xy = (entity:LocalToWorld(entity:OBBCenter())):ToScreen()
-		local sthx, sthy = 0, 0
+		local textHeight, textWidth = 0, 0
 		xy.y = math.min(math.max(64, xy.y), ScrH() - 64)
 		local pad = 3
 			
 		if IsValid(entity) and (entity:GetPos() - LocalPlayer():GetShootPos()):Length() < 120 then
 			local data = fishingmod.InfoTable.Catch[entity:EntIndex()]
-			if(data and data.text) then
-				local text_ = string.Replace(string.Replace(data.text, "\t", ""), "  ", " ")
+			if data and data.text then
+				data.text = string.Replace(string.Replace(data.text, "\t", ""), "  ", " ")
 				surface.SetFont("fixed_Height_Font")
 				surface.SetDrawColor(uiText.r, uiText.g, uiText.b, uiText.a)
-				sthx, sthy = surface.GetTextSize(data.text)
-				sthx, sthy = sthx + 8, sthy + 8
+				textHeight, textWidth = surface.GetTextSize(data.text)
+				textHeight, textWidth = textHeight + 8, textWidth + 8
 				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-				surface.DrawRect(xy.x - sthx / 2 - pad, xy.y - sthy / 2 - 1 - pad, sthx + pad * 2, sthy + pad * 2)
-				surface.DrawRect(xy.x - sthx / 2 + 3 - pad, xy.y - sthy / 2 - 1 + 3 - pad, sthx - 6 + pad * 2, sthy - 6 + pad * 2)
-				draw.DrawText(string.Replace(text_, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (sthy / 2), uiText, 1) -- \t key causes it to snap
+				surface.DrawRect(xy.x - textHeight / 2 - pad, xy.y - textWidth / 2 - 1 - pad, textHeight + pad * 2, textWidth + pad * 2)
+				surface.DrawRect(xy.x - textHeight / 2 + 3 - pad, xy.y - textWidth / 2 - 1 + 3 - pad, textHeight - 6 + pad * 2, textWidth - 6 + pad * 2)
+				draw.DrawText(data.text, "fixed_Height_Font", xy.x, xy.y - (textWidth / 2), uiText, 1) -- \t key causes it to snap
 			end
 				
 			data = fishingmod.InfoTable.Bait[entity:EntIndex()]
-			if(data and data.text) then
+			if data and data.text then
 				surface.SetFont("fixed_Height_Font")
 				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-				sthx, sthy = surface.GetTextSize(string.Replace(string.Replace(data.text, "\t", ""), "\n", ""))
-				sthx, sthy = sthx + 8, sthy + 8
-				surface.DrawRect(xy.x - sthx / 2 - pad, xy.y - sthy / 2 - 1 - pad + 16, sthx + pad * 2, sthy + pad * 1)
-				surface.DrawRect(xy.x - sthx / 2 + 3 - pad, xy.y - sthy / 2 + 2 - pad + 16, sthx - 6 + pad * 2, sthy - 6 + pad * 1)
-				draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (sthy / 2) + 15, uiText, 1)
+				textHeight, textWidth = surface.GetTextSize(string.Replace(string.Replace(data.text, "\t", ""), "\n", ""))
+				textHeight, textWidth = textHeight + 8, textWidth + 8
+				surface.DrawRect(xy.x - textHeight / 2 - pad, xy.y - textWidth / 2 - 1 - pad + 16, textHeight + pad * 2, textWidth + pad * 1)
+				surface.DrawRect(xy.x - textHeight / 2 + 3 - pad, xy.y - textWidth / 2 + 2 - pad + 16, textHeight - 6 + pad * 2, textWidth - 6 + pad * 1)
+				draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (textWidth / 2) + 15, uiText, 1)
 			end
 		end
 	end
 	local chpos = LocalPlayer():GetEyeTraceNoCursor().HitPos
-	if IsValid(LocalPlayer():GetActiveWeapon()) then
-		if LocalPlayer():GetActiveWeapon():GetClass() == "weapon_fishing_rod" then
-			surface.SetDrawColor(crosshair.r, crosshair.g, crosshair.b, crosshair.a)
+	if IsValid(LocalPlayer():GetActiveWeapon()) and LocalPlayer():GetActiveWeapon():GetClass() == "weapon_fishing_rod" then
+		surface.SetDrawColor(crosshair.r, crosshair.g, crosshair.b, crosshair.a)
+		local xy = chpos:ToScreen()
+		surface.DrawRect( xy.x, xy.y+5, 1, 10)
+		surface.DrawRect( xy.x, xy.y-14, 1, 10)
 
-			surface.DrawRect( chpos:ToScreen().x, chpos:ToScreen().y+5, 1, 10)
-			surface.DrawRect( chpos:ToScreen().x, chpos:ToScreen().y-14, 1, 10)
-
-			surface.DrawRect( chpos:ToScreen().x+5, chpos:ToScreen().y, 10, 1 )
-			surface.DrawRect( chpos:ToScreen().x-14, chpos:ToScreen().y, 10, 1 )
-
-		end
+		surface.DrawRect( xy.x+5, xy.y, 10, 1 )
+		surface.DrawRect( xy.x-14, xy.y, 10, 1 )
 	end
 end)
 local force_b = 1

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -139,7 +139,7 @@ end)
 local force_b = 1
 concommand.Add("fishing_mod_b_opens_always", function(ply, cmd, args)
 	if isnumber(tonumber(args[1])) then
-		force_b = math.Clamp(math.Round(args[1]), 0, 1)
+		force_b = math.Clamp(math.Round(tonumber(args[1])), 0, 1)
 	end
 end)
 local ply = LocalPlayer()

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -39,6 +39,7 @@ surface.CreateFont("fixed_NameFont", {
 
 include("cl_networking.lua")
 include("cl_shop_menu.lua")
+fishingmod.ColorTable = fishingmod.LoadUIColors()
 
 fishingmod.CatchTable = {}
 
@@ -65,11 +66,11 @@ hook.Add("InitPostEntity", "Init Fish Mod", function()
 			local view = {}
 			view.origin = ply:GetShootPos() + 
 				(ply:EyeAngles():Right() * 50) + 
-				(Angle(0,ply:EyeAngles().y,0):Forward() * -150) + 
-				(Angle(0,0,ply:EyeAngles().z):Up() * 20)
+				(Angle(0, ply:EyeAngles().y, 0):Forward() * -150) + 
+				(Angle(0, 0, ply:EyeAngles().z):Up() * 20)
 			
 			
-			view.angles = Angle(math.Clamp(ply:EyeAngles().p-30, -70, 15), ply:EyeAngles().y, 0)		
+			view.angles = Angle(math.Clamp(ply:EyeAngles().p -30, -70, 15), ply:EyeAngles().y, 0)		
 			
 			return view
 		end
@@ -77,48 +78,70 @@ hook.Add("InitPostEntity", "Init Fish Mod", function()
 	end
 
 end)
-
+local uiText = fishingmod.DefaultUIColors().uiText
+local bg = fishingmod.DefaultUIColors().uiBackground
+local crosshair = fishingmod.DefaultUIColors().crossHairColor
 hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 	local entity = LocalPlayer():GetEyeTrace().Entity
+	if fishingmod.ColorTable then 
+		crosshair = fishingmod.ColorTable.crossHairColor or fishingmod.DefaultUIColors().crossHairColor
+		uiText = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
+		bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+	end
 	entity = IsValid(entity) and IsValid(entity:GetNWEntity("FMRedirect")) and entity:GetNWEntity("FMRedirect") or entity
-	if not IsValid(entity) then return end
-	
-	local xy = (entity:LocalToWorld(entity:OBBCenter())):ToScreen()
-	local sthx, sthy = 0, 0
-	xy.y = math.min(math.max(64, xy.y), ScrH() - 64)
-	local pad = 3
-		
-	if IsValid(entity) and (entity:GetPos() - LocalPlayer():GetShootPos()):Length() < 120 then
-		local data = fishingmod.InfoTable.Catch[entity:EntIndex()]
-		if(data and data.text) then
-			local text_ = string.Replace(string.Replace(data.text, "\t", ""), "  ", " ")
-			surface.SetFont("fixed_Height_Font")
-			surface.SetDrawColor(color_white.r, color_white.r, color_white.r, color_white.r)
-			sthx, sthy = surface.GetTextSize(data.text)
-			sthx, sthy = sthx + 8, sthy + 8
-			surface.SetDrawColor(0, 0, 0, 144)
-			surface.DrawRect(xy.x - sthx / 2 - pad, xy.y - sthy / 2 - 1 - pad, sthx + pad * 2, sthy + pad * 2)
-			surface.DrawRect(xy.x - sthx / 2 + 3 - pad, xy.y - sthy / 2 - 1 + 3 - pad, sthx - 6 + pad * 2, sthy - 6 + pad * 2)
-			draw.DrawText(string.Replace(text_, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (sthy / 2), color_white, 1) -- \t key causes it to snap
-		end
+	if IsValid(entity) then
+		local xy = (entity:LocalToWorld(entity:OBBCenter())):ToScreen()
+		local sthx, sthy = 0, 0
+		xy.y = math.min(math.max(64, xy.y), ScrH() - 64)
+		local pad = 3
 			
-		data = fishingmod.InfoTable.Bait[entity:EntIndex()]
-		if(data and data.text) then
-			surface.SetFont("fixed_Height_Font")
-			surface.SetDrawColor(0, 0, 0, 144)
-			sthx, sthy = surface.GetTextSize(string.Replace(string.Replace(data.text,"\t",""),"\n",""))
-			sthx, sthy = sthx + 8, sthy + 8
-			surface.DrawRect(xy.x - sthx / 2 - pad, xy.y - sthy / 2 - 1 - pad + 16, sthx + pad * 2, sthy + pad * 1)
-			surface.DrawRect(xy.x - sthx / 2 + 3 - pad, xy.y - sthy / 2 + 2 - pad + 16, sthx - 6 + pad * 2, sthy - 6 + pad * 1)
-			draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (sthy / 2) + 15, color_white, 1)
+		if IsValid(entity) and (entity:GetPos() - LocalPlayer():GetShootPos()):Length() < 120 then
+			local data = fishingmod.InfoTable.Catch[entity:EntIndex()]
+			if(data and data.text) then
+				local text_ = string.Replace(string.Replace(data.text, "\t", ""), "  ", " ")
+				surface.SetFont("fixed_Height_Font")
+				surface.SetDrawColor(uiText.r, uiText.g, uiText.b, uiText.a)
+				sthx, sthy = surface.GetTextSize(data.text)
+				sthx, sthy = sthx + 8, sthy + 8
+				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+				surface.DrawRect(xy.x - sthx / 2 - pad, xy.y - sthy / 2 - 1 - pad, sthx + pad * 2, sthy + pad * 2)
+				surface.DrawRect(xy.x - sthx / 2 + 3 - pad, xy.y - sthy / 2 - 1 + 3 - pad, sthx - 6 + pad * 2, sthy - 6 + pad * 2)
+				draw.DrawText(string.Replace(text_, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (sthy / 2), uiText, 1) -- \t key causes it to snap
+			end
+				
+			data = fishingmod.InfoTable.Bait[entity:EntIndex()]
+			if(data and data.text) then
+				surface.SetFont("fixed_Height_Font")
+				surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+				sthx, sthy = surface.GetTextSize(string.Replace(string.Replace(data.text, "\t", ""), "\n", ""))
+				sthx, sthy = sthx + 8, sthy + 8
+				surface.DrawRect(xy.x - sthx / 2 - pad, xy.y - sthy / 2 - 1 - pad + 16, sthx + pad * 2, sthy + pad * 1)
+				surface.DrawRect(xy.x - sthx / 2 + 3 - pad, xy.y - sthy / 2 + 2 - pad + 16, sthx - 6 + pad * 2, sthy - 6 + pad * 1)
+				draw.DrawText(string.Replace(data.text, "\t", ""), "fixed_Height_Font", xy.x, xy.y - (sthy / 2) + 15, uiText, 1)
+			end
+		end
+	end
+	local chpos = LocalPlayer():GetEyeTraceNoCursor().HitPos
+	if IsValid(LocalPlayer():GetActiveWeapon()) then
+		if LocalPlayer():GetActiveWeapon():GetClass() == "weapon_fishing_rod" then
+			surface.SetDrawColor(crosshair.r, crosshair.g, crosshair.b, crosshair.a)
+
+			surface.DrawRect( chpos:ToScreen().x, chpos:ToScreen().y+5, 1, 10)
+			surface.DrawRect( chpos:ToScreen().x, chpos:ToScreen().y-14, 1, 10)
+
+			surface.DrawRect( chpos:ToScreen().x+5, chpos:ToScreen().y, 10, 1 )
+			surface.DrawRect( chpos:ToScreen().x-14, chpos:ToScreen().y, 10, 1 )
+
+			--surface.DrawRect( chpos:ToScreen().x-boxSizeVar, chpos:ToScreen().y-boxSizeVar, boxSizeVar*2, boxSizeVar*2 )
+			--draw.RoundedBox(boxSizeVar, chpos:ToScreen().x-boxSizeVar, chpos:ToScreen().y-boxSizeVar, boxSizeVar*2, boxSizeVar*2, crosshair)
 		end
 	end
 end)
-
+local getbind = input.LookupKeyBinding
 hook.Add("Think", "Fishingmod.Keys:Think", function()
 	local ply = LocalPlayer()
 	if ply:GetFishingRod() and not vgui.CursorVisible() then
-		if input.IsKeyDown(KEY_B) and (not input.LookupKeyBinding(KEY_B) or input.LookupKeyBinding(KEY_B) == "") then
+		if input.IsKeyDown(KEY_B) and (not getbind(KEY_B) or getbind(KEY_B) == "+zoom" or getbind(KEY_B) == "") then
 			local menu = fishingmod.UpgradeMenu
 			if ValidPanel(menu) and not menu:IsVisible() then
 				menu:SetVisible(true)
@@ -147,12 +170,12 @@ timer.Create("Fishingmod:Tick", 2, 0, function()
 		end
 		local size = entity:GetNWFloat("fishingmod size")
 		if entity:GetNWBool("in fishing shelf") and size ~= 0 then
-			entity:SetModelScale(size/entity:BoundingRadius(), 0)
+			entity:SetModelScale(size / entity:BoundingRadius(), 0)
 		end
 	end
 end)
 
-hook.Add("CalcView", "Fishingmod:CalcView", function(ply,offset,angles,fov)
+hook.Add("CalcView", "Fishingmod:CalcView", function(ply, offset, angles, fov)
 	if GetViewEntity() ~= ply then return end
 	local fishingRod = ply:GetFishingRod()
 	if fishingRod and not ply:InVehicle() then
@@ -164,8 +187,8 @@ hook.Add("CalcView", "Fishingmod:CalcView", function(ply,offset,angles,fov)
 
 		local startview = ply:GetShootPos() + 
 			(ply:EyeAngles():Right() * 70) + 
-			(Angle(0,ply:EyeAngles().y,0):Forward() * -120 ) +
-			(Angle(0,0,ply:EyeAngles().r):Up() * -( 10 + ( 180 - 256 * (math.min(view.angles.p, 150 - 90) + 90) / 180) ))
+			(Angle(0, ply:EyeAngles().y, 0):Forward() * -120 ) +
+			(Angle(0, 0, ply:EyeAngles().r):Up() * -( 10 + ( 180 - 256 * (math.min(view.angles.p, 150 - 90) + 90) / 180) ))
 
 
 		-- Trace back from the original eye position, so we don't clip through walls/objects

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -132,16 +132,19 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 			surface.DrawRect( chpos:ToScreen().x+5, chpos:ToScreen().y, 10, 1 )
 			surface.DrawRect( chpos:ToScreen().x-14, chpos:ToScreen().y, 10, 1 )
 
-			--surface.DrawRect( chpos:ToScreen().x-boxSizeVar, chpos:ToScreen().y-boxSizeVar, boxSizeVar*2, boxSizeVar*2 )
-			--draw.RoundedBox(boxSizeVar, chpos:ToScreen().x-boxSizeVar, chpos:ToScreen().y-boxSizeVar, boxSizeVar*2, boxSizeVar*2, crosshair)
 		end
 	end
 end)
-local getbind = input.LookupKeyBinding
+local force_b = 1
+concommand.Add("fishing_mod_b_opens_always", function(ply, cmd, args)
+	if isnumber(tonumber(args[1])) then
+		force_b = math.Clamp(math.Round(args[1]),0,1)
+	end
+end)
 hook.Add("Think", "Fishingmod.Keys:Think", function()
 	local ply = LocalPlayer()
 	if ply:GetFishingRod() and not vgui.CursorVisible() then
-		if input.IsKeyDown(KEY_B) and (not getbind(KEY_B) or getbind(KEY_B) == "+zoom" or getbind(KEY_B) == "") then
+		if input.IsKeyDown(KEY_B) and force_b == 1 then
 			local menu = fishingmod.UpgradeMenu
 			if ValidPanel(menu) and not menu:IsVisible() then
 				menu:SetVisible(true)

--- a/lua/fishing_mod/cl_init.lua
+++ b/lua/fishing_mod/cl_init.lua
@@ -81,8 +81,14 @@ end)
 local ui_text = fishingmod.DefaultUIColors().ui_text
 local bg = fishingmod.DefaultUIColors().ui_background
 local crosshair = fishingmod.DefaultUIColors().crosshair_color
+local entity = NULL
+local xy = {x=0,y=0}
+local text_height, text_width = 0, 0
+local pad = 3
+local data
+local chpos = Vector()
 hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
-	local entity = LocalPlayer():GetEyeTrace().Entity
+	entity = LocalPlayer():GetEyeTrace().Entity
 	if fishingmod.ColorTable then 
 		crosshair = fishingmod.ColorTable.crosshair_color or fishingmod.DefaultUIColors().crosshair_color
 		ui_text = fishingmod.ColorTable.ui_text or fishingmod.DefaultUIColors().ui_text
@@ -90,13 +96,11 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 	end
 	entity = IsValid(entity) and IsValid(entity:GetNWEntity("FMRedirect")) and entity:GetNWEntity("FMRedirect") or entity
 	if IsValid(entity) then
-		local xy = (entity:LocalToWorld(entity:OBBCenter())):ToScreen()
-		local text_height, text_width = 0, 0
+		xy = (entity:LocalToWorld(entity:OBBCenter())):ToScreen()
+		text_height, text_width = 0, 0
 		xy.y = math.min(math.max(64, xy.y), ScrH() - 64)
-		local pad = 3
-			
 		if IsValid(entity) and (entity:GetPos() - LocalPlayer():GetShootPos()):Length() < 120 then
-			local data = fishingmod.InfoTable.Catch[entity:EntIndex()]
+			data = fishingmod.InfoTable.Catch[entity:EntIndex()]
 			if data and data.text then
 				data.text = string.Replace(string.Replace(data.text, "\t", ""), "  ", " ")
 				surface.SetFont("fixed_height_font")
@@ -121,10 +125,10 @@ hook.Add( "HUDPaint", "Fishingmod:HUDPaint", function()
 			end
 		end
 	end
-	local chpos = LocalPlayer():GetEyeTraceNoCursor().HitPos
+	chpos = LocalPlayer():GetEyeTraceNoCursor().HitPos
 	if IsValid(LocalPlayer():GetActiveWeapon()) and LocalPlayer():GetActiveWeapon():GetClass() == "weapon_fishing_rod" then
 		surface.SetDrawColor(crosshair.r, crosshair.g, crosshair.b, crosshair.a)
-		local xy = chpos:ToScreen()
+		xy = chpos:ToScreen()
 		surface.DrawRect( xy.x, xy.y + 5, 1, 10)
 		surface.DrawRect( xy.x, xy.y - 14, 1, 10)
 
@@ -138,9 +142,10 @@ concommand.Add("fishing_mod_b_opens_always", function(ply, cmd, args)
 		force_b = math.Clamp(math.Round(args[1]), 0, 1)
 	end
 end)
+local ply = LocalPlayer()
 hook.Add("Think", "Fishingmod.Keys:Think", function()
-	local ply = LocalPlayer()
-	if ply:GetFishingRod() and not vgui.CursorVisible() then
+	ply = IsValid(LocalPlayer()) and ply or LocalPlayer()
+	if ply.GetFishingRod and ply:GetFishingRod() and not vgui.CursorVisible() then
 		if input.IsKeyDown(KEY_B) and force_b == 1 then
 			local menu = fishingmod.UpgradeMenu
 			if ValidPanel(menu) and not menu:IsVisible() then
@@ -174,10 +179,10 @@ timer.Create("Fishingmod:Tick", 2, 0, function()
 		end
 	end
 end)
-
+local fishingRod
 hook.Add("CalcView", "Fishingmod:CalcView", function(ply, offset, angles, fov)
 	if GetViewEntity() ~= ply then return end
-	local fishingRod = ply:GetFishingRod()
+	fishingRod = ply:GetFishingRod()
 	if fishingRod and not ply:InVehicle() then
 
 		local view = {}

--- a/lua/fishing_mod/cl_networking.lua
+++ b/lua/fishing_mod/cl_networking.lua
@@ -42,6 +42,7 @@ local function UpdatePlayer(ply)
 	local reel_speed = net.ReadInt(16)
 	local string_length = net.ReadInt(16)
 	local force = net.ReadInt(16)
+    local seagull_deter = net.ReadInt(16)
 	local spawned = net.ReadBool()
 	ply.fishingmod = ply.fishingmod or {}
 	if not ply.fishingmod then return end
@@ -49,6 +50,7 @@ local function UpdatePlayer(ply)
 	ply.fishingmod.reel_speed = reel_speed
 	ply.fishingmod.string_length = string_length
 	ply.fishingmod.force = force
+	ply.fishingmod.seagull_deter = seagull_deter
 	
 	ply.fishingmod.money = money
 	ply.fishingmod.level = fishingmod.ExpToLevel(exp)

--- a/lua/fishing_mod/cl_networking.lua
+++ b/lua/fishing_mod/cl_networking.lua
@@ -154,7 +154,6 @@ net.Receive("Fishingmod:Bait", function()
 end)
 
 hook.Add("Tick", "Fishingmod.CleanInfo:Tick", function()
-	if not fishingmod then return end
 	for key, value in pairs(fishingmod.InfoTable.Catch) do
 		if not IsValid(Entity(key)) then
 			fishingmod.InfoTable.Catch[key] = nil

--- a/lua/fishing_mod/cl_networking.lua
+++ b/lua/fishing_mod/cl_networking.lua
@@ -27,7 +27,9 @@ net.Receive("Fishingmod:BaitPrices", function()
 	local multiplier = net.ReadFloat()
 	if not fishingmod.BaitTable[name] then return end
 	fishingmod.BaitTable[name].multiplier = multiplier
-	fishingmod.UpdateSales()
+	if fishingmod.UpdateSales then
+		fishingmod.UpdateSales()
+	end
 end)
 
 
@@ -152,6 +154,7 @@ net.Receive("Fishingmod:Bait", function()
 end)
 
 hook.Add("Tick", "Fishingmod.CleanInfo:Tick", function()
+	if not fishingmod then return end
 	for key, value in pairs(fishingmod.InfoTable.Catch) do
 		if not IsValid(Entity(key)) then
 			fishingmod.InfoTable.Catch[key] = nil

--- a/lua/fishing_mod/cl_networking.lua
+++ b/lua/fishing_mod/cl_networking.lua
@@ -95,11 +95,8 @@ net.Receive("Fishingmod:Catch", function()
 	local value = net.ReadInt(32)
 	
 	value = value == 0 and "????" or value
-	if(UndercorateNick) then
-		owner = UndercorateNick(owner)
-	elseif(EasyChat) then
-		owner = ec_markup.Parse(owner):GetText()
-	end
+    owner = EasyChat and ec_markup.Parse(owner):GetText() or UndercorateNick and UndercorateNick(owner) or owner
+
 	fishingmod.InfoTable.Catch[entity] = {
 		friendly = friendly,
 		caught = caught,
@@ -140,11 +137,8 @@ net.Receive("Fishingmod:Bait", function()
 		owner = owner,
 	}
 	local nameparse = ply:Nick()
-	if(UndercorateNick) then
-		nameparse = UndercorateNick(nameparse)
-	elseif(EasyChat) then
-		nameparse = ec_markup.Parse(nameparse):GetText()
-	end
+	nameparse = EasyChat and ec_markup.Parse(nameparse):GetText() or UndercorateNick and UndercorateNick(nameparse) or nameparse
+
 	local text = Format([[
 		This bait is owned by %s.
 	]],

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -58,7 +58,7 @@ function fishingmod.SaveUIColors()
 	new_data = nil
 end
 function fishingmod.LoadUIColors()
-	local tempCol = Color(0, 0, 0, 72)
+	local temp_col = Color(0, 0, 0, 72)
 	if file.Exists(fishingmod_data_path, "DATA") then
 		if file.Exists(fishingmod_data_path .. fishingmod_data_file_name, "DATA") then
 			local temp_data = util.JSONToTable(file.Read(fishingmod_data_path .. fishingmod_data_file_name, "DATA"))
@@ -66,9 +66,8 @@ function fishingmod.LoadUIColors()
 			if temp_data then
 				for k, v in pairs(temp_data) do
 					if k and v then
-						if #tostring(k) < 4 then return end
-						if #tostring(v) < 4 then return end
-						temp_data[k] = string.ToColor(v) or tempCol
+						if #tostring(k) < 4 or #tostring(v) < 4 then return fishingmod.DefaultUIColors() end
+						temp_data[k] = string.ToColor(v) or temp_col
 					end
 				end
 				table.Merge(return_data, temp_data)
@@ -94,7 +93,12 @@ local fishingmod_sprite_plus, a = Material("sprites/key_12")
 fishingmod_sprite_minus:SetInt("$flags", 2097152)
 fishingmod_sprite_plus:SetInt("$flags", 2097152)
 
-local back_ground = fishingmod.DefaultUIColors().ui_background
+local col_green = Color(0, 255, 0)
+local col_white = Color(255, 255, 255)
+
+local margin = 3
+
+local background = fishingmod.DefaultUIColors().ui_background
 local ui_text = fishingmod.DefaultUIColors().ui_text
 local button_not_selected = fishingmod.DefaultUIColors().ui_text_bg
 local ui_button_hovered = fishingmod.DefaultUIColors().ui_button_hovered
@@ -106,7 +110,7 @@ local PANEL = {} -- Main panel
 
 function PANEL:Init()
 	if fishingmod.ColorTable then
-		back_ground = fishingmod.ColorTable.ui_background or back_ground
+		background = fishingmod.ColorTable.ui_background or background
 		ui_text = fishingmod.ColorTable.ui_text or ui_text
 		button_not_selected = fishingmod.ColorTable.ui_text_bg or button_not_selected
 		ui_button_hovered = fishingmod.ColorTable.ui_button_hovered or ui_button_hovered
@@ -132,87 +136,87 @@ function PANEL:Init()
 
 	local xpx, xpy = self:GetSize()
 
-	local upgradesbutton = vgui.Create("DButton", self) -- upgrades
-	local baitsbutton = vgui.Create("DButton", self) -- baits shop
-	local customizationbutton = vgui.Create("DButton", self) -- customization tab
+	local upgrades_button = vgui.Create("DButton", self) -- upgrades
+	local baits_button = vgui.Create("DButton", self) -- baits shop
+	local customization_button = vgui.Create("DButton", self) -- customization tab
 
-	upgradesbutton.selected = true
-	baitsbutton.selected = false
-	upgradesbutton:SetPos(3, 24)
-	upgradesbutton:SetSize((xpx - 6) / 3, 22)
-	upgradesbutton:SetText("Upgrades")
-	function upgradesbutton.Think()
+	upgrades_button.selected = true
+	baits_button.selected = false
+	upgrades_button:SetPos(margin, 24)
+	upgrades_button:SetSize((xpx - margin * 2) / margin, 22)
+	upgrades_button:SetText("Upgrades")
+	function upgrades_button.Think()
 		xpx, xpy = self:GetSize()
-		upgradesbutton:SetSize((xpx - 6) / 3, 22)
+		upgrades_button:SetSize((xpx - margin * 2) / margin, 22)
 	end
-	upgradesbutton:SetTextColor(ui_text)
-	upgradesbutton.DoClick = function()
-		upgradesbutton:SetColor(ui_text)
-		baitsbutton:SetColor(nopres)
-		customizationbutton:SetColor(nopres)
+	upgrades_button:SetTextColor(ui_text)
+	upgrades_button.DoClick = function()
+		upgrades_button:SetColor(ui_text)
+		baits_button:SetColor(nopres)
+		customization_button:SetColor(nopres)
 
-		baitsbutton:SetTextColor(button_not_selected)
-		customizationbutton:SetTextColor(button_not_selected)
+		baits_button:SetTextColor(button_not_selected)
+		customization_button:SetTextColor(button_not_selected)
 
-		upgradesbutton.selected = true
-		baitsbutton.selected = false
-		customizationbutton.selected = false
+		upgrades_button.selected = true
+		baits_button.selected = false
+		customization_button.selected = false
 
 		self.customization:Hide()
 		self.upgrade:Show()
 		self.baitshop:Hide()
 	end
-	upgradesbutton.Paint = function(self, w, h)
+	upgrades_button.Paint = function(self, w, h)
 		if self.selected then
-			upgradesbutton:SetColor(ui_text)
+			upgrades_button:SetColor(ui_text)
 		elseif not self.selected then
-			upgradesbutton:SetColor(button_not_selected)
+			upgrades_button:SetColor(button_not_selected)
 		end
-		if upgradesbutton:IsHovered() then
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
-		elseif upgradesbutton.selected then
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		if upgrades_button:IsHovered() then
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
+		elseif upgrades_button.selected then
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	baitsbutton:SetPos(3 + (xpx - 6) / 3, 24) -- baits shop start of conf
-	baitsbutton:SetSize((xpx - 6) / 3, 22)
-	function baitsbutton.Think()
+	baits_button:SetPos(margin + (xpx - margin * 2) / margin, 24) -- baits shop start of conf
+	baits_button:SetSize((xpx - margin * 2) / margin, 22)
+	function baits_button.Think()
 		xpx, xpy = self:GetSize()
-		baitsbutton:SetSize((xpx - 6) / 3, 22)
-		baitsbutton:SetPos(3 + (xpx - 6) / 3, 24)
+		baits_button:SetSize((xpx - margin * 2) / margin, 22)
+		baits_button:SetPos(margin + (xpx - margin * 2) / margin, 24)
 	end
-	baitsbutton:SetText("Bait Shop")
-	baitsbutton:SetTextColor(button_not_selected)
-	baitsbutton.DoClick = function()
-		baitsbutton:SetColor(ui_text)
-		upgradesbutton:SetColor(nopres)
-		customizationbutton:SetColor(nopres)
+	baits_button:SetText("Bait Shop")
+	baits_button:SetTextColor(button_not_selected)
+	baits_button.DoClick = function()
+		baits_button:SetColor(ui_text)
+		upgrades_button:SetColor(nopres)
+		customization_button:SetColor(nopres)
 
-		upgradesbutton:SetTextColor(button_not_selected)
-		customizationbutton:SetTextColor(button_not_selected)
+		upgrades_button:SetTextColor(button_not_selected)
+		customization_button:SetTextColor(button_not_selected)
 
-		upgradesbutton.selected = false
-		baitsbutton.selected = true
-		customizationbutton.selected = false
+		upgrades_button.selected = false
+		baits_button.selected = true
+		customization_button.selected = false
 
 		self.customization:Hide()
 		self.upgrade:Hide()
 		self.baitshop:Show()
 	end
-	baitsbutton.Paint = function(self, w, h)
+	baits_button.Paint = function(self, w, h)
 		if self.selected then
-			baitsbutton:SetColor(ui_text)
+			baits_button:SetColor(ui_text)
 		elseif not self.selected then
-			baitsbutton:SetColor(button_not_selected)
+			baits_button:SetColor(button_not_selected)
 		end
-		if baitsbutton:IsHovered() then
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
-		elseif baitsbutton.selected then
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		if baits_button:IsHovered() then
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
+		elseif baits_button.selected then
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -220,51 +224,51 @@ function PANEL:Init()
 	end
 
 
-	customizationbutton:SetPos(3 + (xpx - 6) / 3, 24) -- baits shop start of conf
-	customizationbutton:SetSize((xpx - 6) / 3, 22)
+	customization_button:SetPos(margin + (xpx - margin * 2) / margin, 24) -- baits shop start of conf
+	customization_button:SetSize((xpx - margin * 2) / margin, 22)
 	
-	function customizationbutton.Think()
+	function customization_button.Think()
 		xpx, xpy = self:GetSize()
-		if xpx % 3 == 2 then
-			customizationbutton:SetSize(math.Round((xpx - 6) / 3) + 1 , 22)
-			customizationbutton:SetPos(2 + (xpx - 6) / 3 * 2 , 24)
-		elseif xpx % 3 == 1  then
-			customizationbutton:SetSize(math.Round((xpx - 6) / 3) + 1, 22)
-			customizationbutton:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
+		if xpx % margin == 2 then -- odd widths
+			customization_button:SetSize(math.Round((xpx - margin * 2) / margin) + 1 , 22)
+			customization_button:SetPos(margin - 1 + (xpx - margin * 2) / margin * 2 , 24)
+		elseif xpx % margin == 1  then
+			customization_button:SetSize(math.Round((xpx - margin * 2) / margin) + 1, 22)
+			customization_button:SetPos(margin + (xpx - margin * 2) / margin * 2 , 24)
 		else
-			customizationbutton:SetSize(math.Round((xpx - 6) / 3) , 22)
-			customizationbutton:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
+			customization_button:SetSize(math.Round((xpx - margin * 2) / margin) , 22)
+			customization_button:SetPos(margin + (xpx - margin * 2) / margin * 2 , 24)
 		end
 	end
-	customizationbutton:SetText("Customize")
-	customizationbutton:SetTextColor(button_not_selected)
-	customizationbutton.DoClick = function()
-		customizationbutton:SetColor(ui_text)
-		upgradesbutton:SetColor(nopres)
-		baitsbutton:SetColor(nopres)
+	customization_button:SetText("Customize")
+	customization_button:SetTextColor(button_not_selected)
+	customization_button.DoClick = function()
+		customization_button:SetColor(ui_text)
+		upgrades_button:SetColor(nopres)
+		baits_button:SetColor(nopres)
 
-		upgradesbutton:SetTextColor(button_not_selected)
-		baitsbutton:SetTextColor(button_not_selected)
+		upgrades_button:SetTextColor(button_not_selected)
+		baits_button:SetTextColor(button_not_selected)
 
-		upgradesbutton.selected = false
-		baitsbutton.selected = false
-		customizationbutton.selected = true
+		upgrades_button.selected = false
+		baits_button.selected = false
+		customization_button.selected = true
 
 		self.customization:Show()
 		self.upgrade:Hide()
 		self.baitshop:Hide()
 
 	end
-	customizationbutton.Paint = function(self, w, h)
+	customization_button.Paint = function(self, w, h)
 		if self.selected then
-			customizationbutton:SetColor(ui_text)
+			customization_button:SetColor(ui_text)
 		elseif not self.selected then
-			customizationbutton:SetColor(button_not_selected)
+			customization_button:SetColor(button_not_selected)
 		end
-		if(customizationbutton:IsHovered()) then
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
-		elseif(customizationbutton.selected) then
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		if(customization_button:IsHovered()) then
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
+		elseif(customization_button.selected) then
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -274,39 +278,39 @@ function PANEL:Init()
 
 	function self:Paint()
 		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
-		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
-	local closebutton = vgui.Create("DButton", self)
+	local close_button = vgui.Create("DButton", self)
 	local x, y = self:GetSize()
-	closebutton.ButtonW = 60
-	closebutton:SetSize(closebutton.ButtonW, 18)
-	closebutton:SetText("Close")
-	closebutton:SetTextColor(ui_text)
-	closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
-	closebutton.DoClick = function()
+	close_button.ButtonW = 60
+	close_button:SetSize(close_button.ButtonW, 18)
+	close_button:SetText("Close")
+	close_button:SetTextColor(ui_text)
+	close_button:SetPos(x - close_button.ButtonW - margin, margin)
+	close_button.DoClick = function()
 		self:Close()
 	end
 	function self:OnSizeChanged(x, y)
-		closebutton:SetPos(math.max(x - closebutton.ButtonW - 3, 3), 3)
-		closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
+		close_button:SetPos(math.max(x - close_button.ButtonW - margin, margin), margin)
+		close_button:SetSize(math.min(close_button.ButtonW, x - margin * 2) , 18 )
 	end
-	closebutton.Paint = function(self, w, h)
+	close_button.Paint = function(self, w, h)
 		self:GetParent().lblTitle:SetTextColor(ui_text)
-		closebutton:SetTextColor(ui_text)
-		if(closebutton:IsDown() ) then
+		close_button:SetTextColor(ui_text)
+		if(close_button:IsDown() ) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(closebutton:IsHovered()) then
+		elseif(close_button:IsHovered()) then
 			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	
 	function self.baitshop:Paint()
-		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -322,16 +326,16 @@ local PANEL = {}
 
 function PANEL:Init()
 	local x, y = self:GetParent():GetSize()
-	self:SetSize(x - 6 , y - 3 - 46)
+	self:SetSize(x - margin * 2 , y - margin - 46)
 	function self:Think()
 		x, y = self:GetParent():GetSize()
-		self:SetSize(x - 6, y - 3 - 46 )
+		self:SetSize(x - margin * 2, y - margin - 46 )
 	end
-	self:SetPos(3, 46)
+	self:SetPos(margin, 46)
 	self:SetPadding(10)
 	function self:Paint()
 		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
-		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		self.money:SetTextColor(ui_text)
 		return true
@@ -372,12 +376,12 @@ local PANEL = {}
 function PANEL:Init()
 	
 	local x, y = self:GetParent():GetSize()
-	self:SetSize(x - 6, y - 3 - 46)
+	self:SetSize(x - margin * 2, y - margin - 46)
 	function self:Think()
 		x, y = self:GetParent():GetSize()
-		self:SetSize(x - 6, y - 3 - 46)
+		self:SetSize(x - margin * 2, y - margin - 46)
 	end
-	self:SetPos(3, 46)
+	self:SetPos(margin, 46)
 	self:EnableHorizontal(true)
 	self:EnableVerticalScrollbar(true)
 	self:SetVisible(false)
@@ -426,14 +430,14 @@ local PANEL = {}
 
 function PANEL:Init()
 	local x, y = self:GetParent():GetSize()
-	self:SetSize(x - 6, y - 3 - 46)
-	self:SetPos(3, 46)
+	self:SetSize(x - margin * 2, y - margin - 46)
+	self:SetPos(margin, 46)
 	self:SetVisible(false)
 	function self:Think()
 		x, y = self:GetParent():GetSize()
-		self:SetSize(x - 6, y - 3 - 46)
+		self:SetSize(x - margin * 2, y - margin - 46)
 		if fishingmod.ColorTable then
-			back_ground = fishingmod.ColorTable.ui_background or back_ground
+			background = fishingmod.ColorTable.ui_background or background
 			ui_text = fishingmod.ColorTable.ui_text or ui_text
 			button_not_selected = fishingmod.ColorTable.ui_text_bg or button_not_selected
 			ui_button_hovered = fishingmod.ColorTable.ui_button_hovered or ui_button_hovered
@@ -444,117 +448,117 @@ function PANEL:Init()
 		end
 	end
 
-	local savebutton = vgui.Create("DButton", self)
-	savebutton:SetPos(10, 50)
-	savebutton:SetSize(120, 30)
-	savebutton:SetTextColor(ui_text)
-	savebutton:SetText("Save")
-	savebutton.Paint = function(self, w, h)
-		savebutton:SetTextColor(ui_text)
-		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+	local save_button = vgui.Create("DButton", self)
+	save_button:SetPos(10, 50)
+	save_button:SetSize(120, 30)
+	save_button:SetTextColor(ui_text)
+	save_button:SetText("Save")
+	save_button.Paint = function(self, w, h)
+		save_button:SetTextColor(ui_text)
+		surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	savebutton.DoClick = function()
+	save_button.DoClick = function()
 		if fishingmod.SaveUIColors then
 			fishingmod.SaveUIColors()
-			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been saved!")
+			chat.AddText(col_green, "[Fishing Mod]", col_white, ": Colors have been saved!")
 		end
 	end
-	local defaultsbutton = vgui.Create("DButton", self)
-	defaultsbutton:SetPos(10, 90)
-	defaultsbutton:SetSize(120, 30)
-	defaultsbutton:SetTextColor(ui_text)
-	defaultsbutton:SetText("Defaults")
-	defaultsbutton.Paint = function(self, w, h)
-		defaultsbutton:SetTextColor(ui_text)
-		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+	local defaults_button = vgui.Create("DButton", self)
+	defaults_button:SetPos(10, 90)
+	defaults_button:SetSize(120, 30)
+	defaults_button:SetTextColor(ui_text)
+	defaults_button:SetText("Defaults")
+	defaults_button.Paint = function(self, w, h)
+		defaults_button:SetTextColor(ui_text)
+		surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	defaultsbutton.DoClick = function()
+	defaults_button.DoClick = function()
 		if fishingmod.DefaultUIColors then
 			fishingmod.ColorTable = fishingmod.DefaultUIColors()
-			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been set to default!")
+			chat.AddText(col_green, "[Fishing Mod]", col_white, ": Colors have been set to default!")
 		end
 	end
 	
-	local combobox = vgui.Create("DComboBox", self )
-	combobox:SetPos(10, 10)
-	combobox:SetSize(120, 30)
-	combobox:SetValue("Select element")
+	local combo_box = vgui.Create("DComboBox", self )
+	combo_box:SetPos(10, 10)
+	combo_box:SetSize(120, 30)
+	combo_box:SetValue("Select element")
 	if fishingmod.ColorTable then
 		if fishingmod.LoadUIColors then
 			for k, v in pairs(fishingmod.LoadUIColors()) do
-				combobox:AddChoice(translation[k])
+				combo_box:AddChoice(translation[k])
 			end
 		end
 	end
-	combobox.Paint = function(self, w, h)
-		combobox:SetTextColor(ui_text)
-		if(combobox:IsDown()) then
+	combo_box.Paint = function(self, w, h)
+		combo_box:SetTextColor(ui_text)
+		if(combo_box:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(combobox:IsHovered()) then
+		elseif(combo_box:IsHovered()) then
 			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
-	local colormixer = vgui.Create( "DColorMixer", self)
+	local color_mixer = vgui.Create( "DColorMixer", self)
 	local x, y = self:GetSize()
-	colormixer:SetPos(120 + 20, 10)
-	colormixer:SetWangs(true)
-	colormixer:SetPalette(false)
-	colormixer:SetSize(x - 10 - 120 - 20, y - 20)
-	function colormixer:ValueChanged(col)
+	color_mixer:SetPos(120 + 20, 10)
+	color_mixer:SetWangs(true)
+	color_mixer:SetPalette(false)
+	color_mixer:SetSize(x - 10 - 120 - 20, y - 20)
+	function color_mixer:ValueChanged(col)
 		if editable and editable != "" and fishingmod.DefaultUIColors()[editable] then
 			fishingmod.ColorTable[editable] = Color(col.r, col.g, col.b, col.a)
 		end
 	end
-	function combobox.OnSelect(self, val, str)
+	function combo_box.OnSelect(self, val, str)
 		if type(str)=="string" and str != "" then
 			editable = translation[str]
 			if fishingmod.ColorTable[editable] then
-				colormixer:SetColor(fishingmod.ColorTable[editable])
+				color_mixer:SetColor(fishingmod.ColorTable[editable])
 			end
 		end
 	end
 	
-	function savebutton:Paint(w, h)
-		savebutton:SetTextColor(ui_text)
-		if(savebutton:IsDown()) then
+	function save_button:Paint(w, h)
+		save_button:SetTextColor(ui_text)
+		if(save_button:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(savebutton:IsHovered()) then
+		elseif(save_button:IsHovered()) then
 			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
-	function defaultsbutton:Paint(w, h)
-		defaultsbutton:SetTextColor(ui_text)
-		if(defaultsbutton:IsDown()) then
+	function defaults_button:Paint(w, h)
+		defaults_button:SetTextColor(ui_text)
+		if(defaults_button:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(defaultsbutton:IsHovered()) then
+		elseif(defaults_button:IsHovered()) then
 			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+			surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	function self:Paint()
 		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
-		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
+		surface.SetDrawColor(background.r, background.g, background.b, background.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
 	function self:OnSizeChanged(x, y)
-		colormixer:SetSize(math.max(math.min(140, x - 20), x - 10 - 120 - 20), y - 20)
-		colormixer:SetPos(math.min(120 + 20, math.max(x - 150, 10)), 10)
-		combobox:SetSize(math.min(120, x - 170), math.min(30, y - 20))
-		savebutton:SetSize(math.min(120, x - 170), math.min(30, y - 60))
-		defaultsbutton:SetSize(math.min(120, x - 170), math.min(30, y - 100))
+		color_mixer:SetSize(math.max(math.min(140, x - 20), x - 10 - 120 - 20), y - 20)
+		color_mixer:SetPos(math.min(120 + 20, math.max(x - 150, 10)), 10)
+		combo_box:SetSize(math.min(120, x - 170), math.min(30, y - 20))
+		save_button:SetSize(math.min(120, x - 170), math.min(30, y - 60))
+		defaults_button:SetSize(math.min(120, x - 170), math.min(30, y - 100))
 	end
 end
 
@@ -658,7 +662,7 @@ function PANEL:Init()
 end
 
 function PANEL:SetSale(multiplier)
-	self.percent = math.Round((multiplier * - 1 + 1) * 100)
+	self.percent = math.Round((-multiplier + 1) * 100)
 end
 
 function PANEL:SetGray(bool)

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -1,20 +1,127 @@
-local PANEL = {} -- Main panel
+function fishingmod.DefaultUIColors()
+	return {
+		["uiText"] = Color(255, 255, 255, 255),
+		["uiTextCaught"] = Color(0, 255, 0, 255),
+		["uiTextBg"] = Color(160, 160, 160, 255),
+		["uiButtonSelected"] = Color(0, 0, 0, 144),
+		["uiButtonDeSelected"] = Color(0, 0, 0, 72),
+		["uiButtonHovered"] = Color(120, 120, 120, 144),
+		["uiButtonPressed"] = Color(0, 0, 0, 50),
+		["uiBackground"] = Color(0, 0, 0, 225),
+		["xpBarForeGr"] = Color(0, 200, 0, 255),
+		["xpBarBackGr"] = Color(255, 255, 255, 55),
+		["xpBarText"] = Color(0, 0, 0, 255),
+		["crossHairColor"] = Color(255,255,255,127),
+	}
+end
+local translation = {
+	["uiText"] = "General Text",
+	["uiTextCaught"] = "Catch Text",
+	["uiTextBg"] = "Background Text",
+	["uiButtonSelected"] = "Selected Button",
+	["uiButtonDeSelected"] = "Button De-selected",
+	["uiButtonHovered"] = "Button Hovered",
+	["uiButtonPressed"] = "Button Pressed",
+	["uiBackground"] = "Background",
+	["xpBarForeGr"] = "XP Bar Foreground",
+	["xpBarBackGr"] = "XP Bar Background",
+	["xpBarText"] = "XP Bar Text",
+	["crossHairColor"] = "Crosshair",
+ -- both ways
+	["General Text"] = "uiText",
+	["Catch Text"] = "uiTextCaught",
+	["Background Text"] = "uiTextBg",
+	["Selected Button"] = "uiButtonSelected",
+	["Button De-selected"] = "uiButtonDeSelected",
+	["Button Hovered"] = "uiButtonHovered",
+	["Button Pressed"] = "uiButtonPressed",
+	["Background"] = "uiBackground",
+	["XP Bar Foreground"] = "xpBarForeGr",
+	["XP Bar Background"] = "xpBarBackGr",
+	["XP Bar Text"] = "xpBarText",
+	["Crosshair"] = "crossHairColor",
+}
+local fishingmodDataPath, fishingmodDataFileName = "fishingmod", "/ui_color_data.txt"
+function fishingmod.SaveUIColors()
+    if not file.Exists(fishingmodDataPath, "DATA") then
+        file.CreateDir(fishingmodDataPath)
+	end
+	local newData = {}
+	local t = fishingmod.DefaultUIColors()
+	if fishingmod.ColorTable then
+		for k, v in pairs(fishingmod.ColorTable) do
+			newData[k] = tostring(v.r) .. " " .. tostring(v.g) .. " " .. tostring(v.b) .. " ".. tostring(v.a)
+		end
+		table.Merge(t, newData)
+	end
+	file.Write(fishingmodDataPath .. fishingmodDataFileName, util.TableToJSON(t, false))
+	newData = nil
+end
+function fishingmod.LoadUIColors()
+	local tempCol = Color(0, 0, 0, 72)
+	if file.Exists(fishingmodDataPath, "DATA") then
+		if file.Exists(fishingmodDataPath .. fishingmodDataFileName, "DATA") then
+			local t_ = util.JSONToTable(file.Read(fishingmodDataPath .. fishingmodDataFileName, "DATA"))
+			local t = fishingmod.DefaultUIColors()
+			if t_ then
+				for k, v in pairs(t_) do
+					if k and v then
+						if #tostring(k) < 4 then return end
+						if #tostring(v) < 4 then return end
+						t_[k] = string.ToColor(v) or tempCol
+					end
+				end
+				table.Merge(t, t_)
+			end
+			t_ = {}
+			return t
+		else
+			return fishingmod.DefaultUIColors() -- return defaults if the file does not exist
+		end
+	else
+		return fishingmod.DefaultUIColors() -- return defaults if the folder does not exist
+	end
+end
+fishingmod.ColorTable = fishingmod.LoadUIColors()
+
+
+if not fishingmod.ColorTable then
+	fishingmod.ColorTable = fishingmod.DefaultUIColors()
+end
 
 local FishingMod_spriteMinus, a = Material("sprites/key_13")
 local FishingMod_spritePlus, a = Material("sprites/key_12")
 FishingMod_spriteMinus:SetInt("$flags", 2097152)
 FishingMod_spritePlus:SetInt("$flags", 2097152)
-local black = Color(0, 0, 0, 144)
-local selected = Color(255, 255, 255, 255)
-local grey = Color(160, 160, 160, 255)
-function PANEL:Init()
 
+local bg = fishingmod.ColorTable.uiBackground
+local sel = fishingmod.ColorTable.uiText
+local nosel = fishingmod.ColorTable.uiTextBg
+local hov = fishingmod.ColorTable.uiButtonHovered
+local nopres = fishingmod.ColorTable.uiButtonDeSelected
+local pres = fishingmod.ColorTable.uiButtonPressed
+local masterX, masterY = 354, 224
+
+local PANEL = {} -- Main panel
+
+function PANEL:Init()
+	if fishingmod then
+		if fishingmod.ColorTable then
+			bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+			sel = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
+			nosel = fishingmod.ColorTable.uiTextBg or fishingmod.DefaultUIColors().uiTextBg
+			hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
+			nopres = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
+			pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
+		end
+	end
 	self:MakePopup()
 	self:SetDeleteOnClose(false)
 	self:SetSizable(true)
 	self:SetTitle("Fishing Mod")
+	self.lblTitle:SetTextColor(sel)
 	self:ShowCloseButton(false)
-	self:SetSize(354, 224)
+	self:SetSize(masterX, masterY)
 	self:Center()
 
 	self.baitshop = vgui.Create("Fishingmod:BaitShop", self)
@@ -23,74 +130,153 @@ function PANEL:Init()
 	
 	self.upgrade = vgui.Create("Fishingmod:Upgrade", self)
 
+	self.customization = vgui.Create("Fishingmod:Customization", self)
+
 	local xpx, xpy = self:GetSize()
 
 	local upgradesbutton = vgui.Create("DButton", self) -- upgrades
 	local baitsbutton = vgui.Create("DButton", self) -- baits shop
-	upgradesbutton.selected = true
-	baitsbutton.selected = false
+	local cus = vgui.Create("DButton", self) -- customization tab
+
+	upgradesbutton.sel = true
+	baitsbutton.sel = false
 	upgradesbutton:SetPos(3, 24)
-	upgradesbutton:SetSize((xpx - 6) / 2, 22)
+	upgradesbutton:SetSize((xpx - 6) / 3, 22)
 	upgradesbutton:SetText("Upgrades")
 	function upgradesbutton.Think()
 		xpx, xpy = self:GetSize()
-		upgradesbutton:SetSize((xpx - 6) / 2, 22)
+		upgradesbutton:SetSize((xpx - 6) / 3, 22)
 	end
-	upgradesbutton:SetTextColor(selected)
+	upgradesbutton:SetTextColor(sel)
 	upgradesbutton.DoClick = function()
-		baitsbutton:SetColor(grey)
-		upgradesbutton:SetColor(selected)
-		upgradesbutton.selected = true
-		baitsbutton.selected = false
+		upgradesbutton:SetColor(sel)
+		baitsbutton:SetColor(nopres)
+		cus:SetColor(nopres)
+
+		baitsbutton:SetTextColor(nosel)
+		cus:SetTextColor(nosel)
+
+		upgradesbutton.sel = true
+		baitsbutton.sel = false
+		cus.sel = false
+
+		self.customization:Hide()
 		self.upgrade:Show()
 		self.baitshop:Hide()
 	end
 	upgradesbutton.Paint = function(self, w, h)
+		if self.sel then
+			upgradesbutton:SetColor(sel)
+		elseif not self.sel then
+			upgradesbutton:SetColor(nosel)
+		end
 		if(upgradesbutton:IsHovered()) then
-			surface.SetDrawColor(0, 0, 0, 144)
-		elseif(upgradesbutton.selected) then
-			surface.SetDrawColor(0, 0, 0, 144)
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		elseif(upgradesbutton.sel) then
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 		else
-			surface.SetDrawColor(0, 0, 0, 72)
+			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	baitsbutton:SetPos(3 + (xpx - 6) / 2, 24) -- baits shop start of conf
-	baitsbutton:SetSize((xpx - 6) / 2, 22)
+	baitsbutton:SetPos(3 + (xpx - 6) / 3, 24) -- baits shop start of conf
+	baitsbutton:SetSize((xpx - 6) / 3, 22)
 	function baitsbutton.Think()
 		xpx, xpy = self:GetSize()
-		if(xpx % 2 == 1) then
-			baitsbutton:SetSize((xpx - 6) / 2 + 1, 22) -- pixelperfect..
-		else
-			baitsbutton:SetSize((xpx - 6) / 2, 22)
-		end
-		baitsbutton:SetPos(3 + (xpx - 6) / 2, 24)
+		baitsbutton:SetSize((xpx - 6) / 3, 22)
+		baitsbutton:SetPos(3 + (xpx - 6) / 3, 24)
 	end
 	baitsbutton:SetText("Bait Shop")
-	baitsbutton:SetTextColor(grey)
+	baitsbutton:SetTextColor(nosel)
 	baitsbutton.DoClick = function()
-		baitsbutton:SetColor(selected)
-		upgradesbutton:SetColor(grey)
-		upgradesbutton.selected = false
-		baitsbutton.selected = true
+		baitsbutton:SetColor(sel)
+		upgradesbutton:SetColor(nopres)
+		cus:SetColor(nopres)
+
+		upgradesbutton:SetTextColor(nosel)
+		cus:SetTextColor(nosel)
+
+		upgradesbutton.sel = false
+		baitsbutton.sel = true
+		cus.sel = false
+
+		self.customization:Hide()
 		self.upgrade:Hide()
 		self.baitshop:Show()
 	end
 	baitsbutton.Paint = function(self, w, h)
+		if self.sel then
+			baitsbutton:SetColor(sel)
+		elseif not self.sel then
+			baitsbutton:SetColor(nosel)
+		end
 		if(baitsbutton:IsHovered()) then
-			surface.SetDrawColor(0, 0, 0, 144)
-		elseif(baitsbutton.selected) then
-			surface.SetDrawColor(0, 0, 0, 144)
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		elseif(baitsbutton.sel) then
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 		else
-			surface.SetDrawColor(0, 0, 0, 72)
+			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 
+
+	cus:SetPos(3 + (xpx - 6) / 3, 24) -- baits shop start of conf
+	cus:SetSize((xpx - 6) / 3, 22)
+	
+	function cus.Think()
+		xpx, xpy = self:GetSize()
+		if(xpx % 3 == 2) then
+			cus:SetSize(math.Round((xpx - 6) / 3) + 1 , 22)
+			cus:SetPos(2 + (xpx - 6) / 3 * 2 , 24)
+		elseif(xpx % 3 == 1 ) then
+			cus:SetSize(math.Round((xpx - 6) / 3) + 1, 22)
+			cus:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
+		else
+			cus:SetSize(math.Round((xpx - 6) / 3) , 22)
+			cus:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
+		end
+	end
+	cus:SetText("Customize")
+	cus:SetTextColor(nosel)
+	cus.DoClick = function()
+		cus:SetColor(sel)
+		upgradesbutton:SetColor(nopres)
+		baitsbutton:SetColor(nopres)
+
+		upgradesbutton:SetTextColor(nosel)
+		baitsbutton:SetTextColor(nosel)
+
+		upgradesbutton.sel = false
+		baitsbutton.sel = false
+		cus.sel = true
+
+		self.customization:Show()
+		self.upgrade:Hide()
+		self.baitshop:Hide()
+
+	end
+	cus.Paint = function(self, w, h)
+		if self.sel then
+			cus:SetColor(sel)
+		elseif not self.sel then
+			cus:SetColor(nosel)
+		end
+		if(cus:IsHovered()) then
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		elseif(cus.sel) then
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		else
+			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
+		end
+		surface.DrawRect(0, 0, w, h)
+	end
+
+
 	function self:Paint()
-		surface.SetTextColor(255, 255, 255, 255)
-		surface.SetDrawColor(0, 0, 0, 144)
+		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
+		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -99,7 +285,7 @@ function PANEL:Init()
 	closebutton.ButtonW = 60
 	closebutton:SetSize(closebutton.ButtonW, 18)
 	closebutton:SetText("Close")
-	closebutton:SetTextColor(selected)
+	closebutton:SetTextColor(sel)
 	closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
 	closebutton.DoClick = function()
 		self:Close()
@@ -109,18 +295,20 @@ function PANEL:Init()
 		closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
 	end
 	closebutton.Paint = function(self, w, h)
+		self:GetParent().lblTitle:SetTextColor(sel)
+		closebutton:SetTextColor(sel)
 		if(closebutton:IsDown() ) then
-			surface.SetDrawColor(0, 0, 0, 72)
+			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(closebutton:IsHovered()) then
-			surface.SetDrawColor(155, 155, 155, 144)
+			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
 		else
-			surface.SetDrawColor(0, 0, 0, 144)
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	
 	function self.baitshop:Paint()
-		surface.SetDrawColor(0, 0, 0, 144)
+		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -144,15 +332,16 @@ function PANEL:Init()
 	self:SetPos(3, 46)
 	self:SetPadding(10)
 	function self:Paint()
-		surface.SetTextColor(255, 255, 255, 255)
-		surface.SetDrawColor(0, 0, 0, 144)
+		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
+		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
+		self.money:SetTextColor(sel)
 		return true
 	end
 
 	self.money = vgui.Create("DLabel", self)
-	self.money:SetTextColor(selected)
-	self.money.Think = function(self) self:SetText("Money: " .. math.Round(LocalPlayer().fishingmod.money, 2)) end
+	self.money:SetTextColor(sel)
+	self.money.Think = function(self) self:SetText("Money: " .. math.Round(LocalPlayer().fishingmod.money)) end
 	
 	self:AddItem(self.money)
 	
@@ -186,7 +375,6 @@ function PANEL:Init()
 	
 	local x, y = self:GetParent():GetSize()
 	self:SetSize(x - 6, y - 3 - 46)
-	local parent = self:GetParent()
 	function self:Think()
 		x, y = self:GetParent():GetSize()
 		self:SetSize(x - 6, y - 3 - 46)
@@ -200,7 +388,7 @@ function PANEL:Init()
 	for key, data in pairs(fishingmod.BaitTable) do -- sorting by level required because it was semi-random before
 		if(not model_seen[data.models[1]]) then
 			model_seen[data.models[1]] = true -- the system is wack so i beat it back
-			tol_tab[#tol_tab+1] = {
+			tol_tab[#tol_tab + 1] = {
 				price = data.price,
 				name = key,
 				model = data.models[1],
@@ -221,7 +409,7 @@ function PANEL:Init()
 		fishingmod.BaitTable[data.name].icon = icon
 		
 		if(level < data.levelrequired) then
-			icon:SetGrey(true)
+			icon:Setnosel(true)
 		else
 			icon.DoClick = function()
 				RunConsoleCommand("fishing_mod_buy_bait", data.name)
@@ -233,6 +421,150 @@ function PANEL:Init()
 end
 
 vgui.Register("Fishingmod:BaitShop", PANEL, "DPanelList")
+
+
+-- Customization tab
+local PANEL = {}
+
+function PANEL:Init()
+	local x, y = self:GetParent():GetSize()
+	self:SetSize(x - 6, y - 3 - 46)
+	self:SetPos(3, 46)
+	self:SetVisible(false)
+	function self:Think()
+		x, y = self:GetParent():GetSize()
+		self:SetSize(x - 6, y - 3 - 46)
+		if fishingmod then
+			if fishingmod.ColorTable then
+				bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
+				sel = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
+				nosel = fishingmod.ColorTable.uiTextBg or fishingmod.DefaultUIColors().uiTextBg
+				hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
+				nopres = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
+				pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
+			else
+				fishingmod.ColorTable = fishingmod.DefaultUIColors()
+			end
+		end
+	end
+
+	local saveb = vgui.Create("DButton", self)
+	saveb:SetPos(10, 50)
+	saveb:SetSize(120, 30)
+	saveb:SetTextColor(sel)
+	saveb:SetText("Save")
+	saveb.Paint = function(self, w, h)
+		saveb:SetTextColor(sel)
+		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.DrawRect(0, 0, w, h)
+	end
+
+	saveb.DoClick = function()
+		if fishingmod.SaveUIColors then
+			fishingmod.SaveUIColors()
+			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been Saved!")
+		end
+	end
+	local Reset = vgui.Create("DButton", self)
+	Reset:SetPos(10, 90)
+	Reset:SetSize(120, 30)
+	Reset:SetTextColor(sel)
+	Reset:SetText("Reset")
+	Reset.Paint = function(self, w, h)
+		Reset:SetTextColor(sel)
+		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.DrawRect(0, 0, w, h)
+	end
+
+	Reset.DoClick = function()
+		if fishingmod.DefaultUIColors then
+			fishingmod.ColorTable = fishingmod.DefaultUIColors()
+			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been Reset!")
+		end
+	end
+	
+	local cbox = vgui.Create("DComboBox", self )
+	cbox:SetPos(10, 10)
+	cbox:SetSize(120, 30)
+	cbox:SetValue("Select element")
+	if fishingmod.ColorTable then
+		if fishingmod.LoadUIColors then
+			for k, v in pairs(fishingmod.LoadUIColors()) do
+				cbox:AddChoice(translation[k])
+			end
+		end
+	end
+	cbox.Paint = function(self, w, h)
+		cbox:SetTextColor(sel)
+		if(cbox:IsDown()) then
+			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
+		elseif(cbox:IsHovered()) then
+			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+		else
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		end
+		surface.DrawRect(0, 0, w, h)
+	end
+	local dcm = vgui.Create( "DColorMixer", self)
+	local x, y = self:GetSize()
+	dcm:SetPos(120 + 20, 10)
+	dcm:SetWangs(true)
+	dcm:SetPalette(false)
+	dcm:SetSize(x - 10 - 120 - 20, y - 20)
+	function dcm:ValueChanged(col)
+		if editable and editable != "" and fishingmod.DefaultUIColors()[editable] then
+			fishingmod.ColorTable[editable] = Color(col.r, col.g, col.b, col.a)
+		end
+	end
+	function cbox.OnSelect(self, val, str)
+		if type(str)=="string" and str != "" then
+			editable = translation[str]
+			if fishingmod.ColorTable[editable] then
+				dcm:SetColor(fishingmod.ColorTable[editable])
+			end
+		end
+	end
+	
+	function saveb:Paint(w, h)
+		saveb:SetTextColor(sel)
+		if(saveb:IsDown()) then
+			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
+		elseif(saveb:IsHovered()) then
+			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+		else
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		end
+		surface.DrawRect(0, 0, w, h)
+	end
+	function Reset:Paint(w, h)
+		Reset:SetTextColor(sel)
+		if(Reset:IsDown()) then
+			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
+		elseif(Reset:IsHovered()) then
+			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+		else
+			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		end
+		surface.DrawRect(0, 0, w, h)
+	end
+	function self:Paint()
+		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
+		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
+		return true
+	end
+	function self:OnSizeChanged(x, y)
+		dcm:SetSize(math.max(math.min(140, x - 20), x - 10 - 120 - 20), y - 20)
+		dcm:SetPos(math.min(120 + 20, math.max(x - 150, 10)), 10)
+		cbox:SetSize(math.min(120, x - 170), math.min(30, y - 20))
+		saveb:SetSize(math.min(120, x - 170), math.min(30, y - 60))
+		Reset:SetSize(math.min(120, x - 170), math.min(30, y - 100))
+	end
+end
+
+vgui.Register("Fishingmod:Customization", PANEL, "DPanelList")
+
+
 
 
 ------------- Helper components --------------
@@ -255,46 +587,48 @@ function PANEL:Init()
 	end
 	
 	self.rightlabel = vgui.Create("DLabel", self)
+	self.rightlabel:SetTextColor(sel)
 	self.rightlabel:SetSize(100, 30)
 	
 	self.leftlabel = vgui.Create("DLabel", self)
+	self.leftlabel:SetTextColor(sel)
 	self.leftlabel:SetSize(100, 30)
 	
 	self.left:Dock(LEFT)
-	self.leftlabel:SetPos(30, -2)
-	self.rightlabel:SetPos(130, -2)
+	self.leftlabel:SetPos(30, - 2)
+	self.rightlabel:SetPos(130, - 2)
 	self.right:Dock(RIGHT)
 	local selfleft = self.left
-	function self.left:Paint()
+	function self.left:Paint() -- 'sell' skill button
 		surface.SetFont("DebugFixed")
-		surface.SetTextColor(255, 255, 255, 255)
+		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
 		if(selfleft:IsDown()) then
-			surface.SetDrawColor(0, 0, 0, 50)
+			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(selfleft:IsHovered()) then
-			surface.SetDrawColor(155, 155, 155, 100)
+			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
 		else
 			surface.SetDrawColor(0, 0, 0, 100)
 		end
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		surface.SetDrawColor(selected)
+		surface.SetDrawColor(sel)
 		surface.SetMaterial(FishingMod_spriteMinus)
 		surface.DrawTexturedRect(1, 1, self:GetWide() - 2, self:GetTall() - 2)
 		return true
 	end
 	local selfright = self.right
-	function self.right:Paint()
+	function self.right:Paint() -- buy skill button
 		surface.SetFont("DebugFixed")
-		surface.SetTextColor(255, 255, 255, 255)
+		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
 
 		if(selfright:IsDown()) then
-			surface.SetDrawColor(0, 0, 0, 50)
+			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(selfright:IsHovered()) then
-			surface.SetDrawColor(155, 155, 155, 100)
+			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
 		else
 			surface.SetDrawColor(0, 0, 0, 100)
 		end
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		surface.SetDrawColor(selected)
+		surface.SetDrawColor(sel)
 		surface.SetMaterial(FishingMod_spritePlus)
 		surface.DrawTexturedRect(1, 1, self:GetWide() - 2, self:GetTall() - 2)
 		return true
@@ -312,6 +646,8 @@ end
 
 function PANEL:Think()
 	if not self.set then return end
+	self.rightlabel:SetTextColor(sel)
+	self.leftlabel:SetTextColor(sel)
 	self.rightlabel:SetText(LocalPlayer().fishingmod[self.type])
 end
 
@@ -326,11 +662,11 @@ function PANEL:Init()
 end
 
 function PANEL:SetSale(multiplier)
-	self.percent = math.Round((multiplier*-1+1)*100)
+	self.percent = math.Round((multiplier * - 1 + 1) * 100)
 end
 
-function PANEL:SetGrey(bool)
-	self.grey = bool
+function PANEL:Setnosel(bool)
+	self.nosel = bool
 end
 
 function PANEL:PaintOver(w, h)
@@ -338,7 +674,7 @@ function PANEL:PaintOver(w, h)
 
 	draw.SimpleText( self.percent.."% OFF", "DermaDefault", 5, 3, color_black, TEXT_ALIGN_LEFT, TEXT_ALIGN_LEFT)
 	draw.SimpleText( self.percent.."% OFF", "DermaDefault", 4, 2, HSVToColor(math.Clamp(self.percent + 40, 0, 160), 1, 1), TEXT_ALIGN_LEFT, TEXT_ALIGN_LEFT)
-	if self.grey then draw.RoundedBox( 6, 0, 0, 58, 58, Color( 100, 100, 100, 200 ) ) end
+	if self.nosel then draw.RoundedBox( 6, 0, 0, 58, 58, Color( 100, 100, 100, 200 ) ) end
 end
 
 vgui.Register("Fishingmod:SpawnIcon", PANEL, "SpawnIcon")

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -1,80 +1,80 @@
 function fishingmod.DefaultUIColors()
 	return {
-		["uiText"] = Color(255, 255, 255, 255),
-		["uiTextCaught"] = Color(0, 255, 0, 255),
-		["uiTextBg"] = Color(160, 160, 160, 255),
-		["uiButtonSelected"] = Color(0, 0, 0, 144),
-		["uiButtonDeSelected"] = Color(0, 0, 0, 72),
-		["uiButtonHovered"] = Color(120, 120, 120, 144),
-		["uiButtonPressed"] = Color(0, 0, 0, 50),
-		["uiBackground"] = Color(0, 0, 0, 225),
-		["xpBarForeGr"] = Color(0, 200, 0, 255),
-		["xpBarBackGr"] = Color(255, 255, 255, 55),
-		["xpBarText"] = Color(0, 0, 0, 255),
-		["crossHairColor"] = Color(255,255,255,127),
+		["ui_text"] = Color(255, 255, 255, 255),
+		["ui_text_caught"] = Color(0, 255, 0, 255),
+		["ui_text_bg"] = Color(160, 160, 160, 255),
+		["ui_button_selected"] = Color(0, 0, 0, 144),
+		["ui_button_deselected"] = Color(0, 0, 0, 72),
+		["ui_button_hovered"] = Color(120, 120, 120, 144),
+		["ui_button_pressed"] = Color(0, 0, 0, 50),
+		["ui_background"] = Color(0, 0, 0, 225),
+		["xp_bar_fg"] = Color(0, 200, 0, 255),
+		["xp_bar_bg"] = Color(255, 255, 255, 55),
+		["xp_bar_text"] = Color(0, 0, 0, 255),
+		["crosshair_color"] = Color(255,255,255,127),
 	}
 end
 local translation = {
-	["uiText"] = "General Text",
-	["uiTextCaught"] = "Catch Text",
-	["uiTextBg"] = "Background Text",
-	["uiButtonSelected"] = "Selected Button",
-	["uiButtonDeSelected"] = "Button De-selected",
-	["uiButtonHovered"] = "Button Hovered",
-	["uiButtonPressed"] = "Button Pressed",
-	["uiBackground"] = "Background",
-	["xpBarForeGr"] = "XP Bar Foreground",
-	["xpBarBackGr"] = "XP Bar Background",
-	["xpBarText"] = "XP Bar Text",
-	["crossHairColor"] = "Crosshair",
+	["ui_text"] = "General Text",
+	["ui_text_caught"] = "Catch Text",
+	["ui_text_bg"] = "Background Text",
+	["ui_button_selected"] = "Selected Button",
+	["ui_button_deselected"] = "Button De-selected",
+	["ui_button_hovered"] = "Button Hovered",
+	["ui_button_pressed"] = "Button Pressed",
+	["ui_background"] = "Background",
+	["xp_bar_fg"] = "XP Bar Foreground",
+	["xp_bar_bg"] = "XP Bar Background",
+	["xp_bar_text"] = "XP Bar Text",
+	["crosshair_color"] = "Crosshair",
  -- both ways
-	["General Text"] = "uiText",
-	["Catch Text"] = "uiTextCaught",
-	["Background Text"] = "uiTextBg",
-	["Selected Button"] = "uiButtonSelected",
-	["Button De-selected"] = "uiButtonDeSelected",
-	["Button Hovered"] = "uiButtonHovered",
-	["Button Pressed"] = "uiButtonPressed",
-	["Background"] = "uiBackground",
-	["XP Bar Foreground"] = "xpBarForeGr",
-	["XP Bar Background"] = "xpBarBackGr",
-	["XP Bar Text"] = "xpBarText",
-	["Crosshair"] = "crossHairColor",
+	["General Text"] = "ui_text",
+	["Catch Text"] = "ui_text_caught",
+	["Background Text"] = "ui_text_bg",
+	["Selected Button"] = "ui_button_selected",
+	["Button De-selected"] = "ui_button_deselected",
+	["Button Hovered"] = "ui_button_hovered",
+	["Button Pressed"] = "ui_button_pressed",
+	["Background"] = "ui_background",
+	["XP Bar Foreground"] = "xp_bar_fg",
+	["XP Bar Background"] = "xp_bar_bg",
+	["XP Bar Text"] = "xp_bar_text",
+	["Crosshair"] = "crosshair_color",
 }
-local fishingmodDataPath, fishingmodDataFileName = "fishingmod", "/ui_color_data.txt"
+local fishingmod_data_path, fishingmod_data_file_name = "fishingmod", "/ui_color_data.txt"
 function fishingmod.SaveUIColors()
-    if not file.Exists(fishingmodDataPath, "DATA") then
-        file.CreateDir(fishingmodDataPath)
+    if not file.Exists(fishingmod_data_path, "DATA") then
+        file.CreateDir(fishingmod_data_path)
 	end
-	local newData = {}
-	local returnData = fishingmod.DefaultUIColors()
+	local new_data = {}
+	local return_data = fishingmod.DefaultUIColors()
 	if fishingmod.ColorTable then
 		for k, v in pairs(fishingmod.ColorTable) do
-			newData[k] = tostring(v.r) .. " " .. tostring(v.g) .. " " .. tostring(v.b) .. " ".. tostring(v.a)
+			new_data[k] = tostring(v.r) .. " " .. tostring(v.g) .. " " .. tostring(v.b) .. " ".. tostring(v.a)
 		end
-		table.Merge(returnData, newData)
+		table.Merge(return_data, new_data)
 	end
-	file.Write(fishingmodDataPath .. fishingmodDataFileName, util.TableToJSON(returnData, false))
-	newData = nil
+	file.Write(fishingmod_data_path .. fishingmod_data_file_name, util.TableToJSON(return_data, false))
+	new_data = nil
 end
 function fishingmod.LoadUIColors()
 	local tempCol = Color(0, 0, 0, 72)
-	if file.Exists(fishingmodDataPath, "DATA") then
-		if file.Exists(fishingmodDataPath .. fishingmodDataFileName, "DATA") then
-			local tempData = util.JSONToTable(file.Read(fishingmodDataPath .. fishingmodDataFileName, "DATA"))
-			local returnData = fishingmod.DefaultUIColors()
-			if tempData then
-				for k, v in pairs(tempData) do
+	if file.Exists(fishingmod_data_path, "DATA") then
+		if file.Exists(fishingmod_data_path .. fishingmod_data_file_name, "DATA") then
+			local temp_data = util.JSONToTable(file.Read(fishingmod_data_path .. fishingmod_data_file_name, "DATA"))
+			local return_data = fishingmod.DefaultUIColors()
+			if temp_data then
+				for k, v in pairs(temp_data) do
 					if k and v then
 						if #tostring(k) < 4 then return end
 						if #tostring(v) < 4 then return end
-						tempData[k] = string.ToColor(v) or tempCol
+						temp_data[k] = string.ToColor(v) or tempCol
 					end
 				end
-				table.Merge(returnData, tempData)
+				table.Merge(return_data, temp_data)
 			end
-			tempData = {}
-			return returnData
+			temp_data = {}
+			return return_data
 		else
 			return fishingmod.DefaultUIColors() -- return defaults if the file does not exist
 		end
@@ -89,37 +89,37 @@ if not fishingmod.ColorTable then
 	fishingmod.ColorTable = fishingmod.DefaultUIColors()
 end
 
-local FishingMod_spriteMinus, a = Material("sprites/key_13")
-local FishingMod_spritePlus, a = Material("sprites/key_12")
-FishingMod_spriteMinus:SetInt("$flags", 2097152)
-FishingMod_spritePlus:SetInt("$flags", 2097152)
+local fishingmod_sprite_minus, a = Material("sprites/key_13")
+local fishingmod_sprite_plus, a = Material("sprites/key_12")
+fishingmod_sprite_minus:SetInt("$flags", 2097152)
+fishingmod_sprite_plus:SetInt("$flags", 2097152)
 
-local backGround = fishingmod.DefaultUIColors().uiBackground
-local uiText = fishingmod.DefaultUIColors().uiText
-local buttonNotSelected = fishingmod.DefaultUIColors().uiTextBg
-local uiButtonHovered = fishingmod.DefaultUIColors().uiButtonHovered
-local nopres = fishingmod.DefaultUIColors().uiButtonDeSelected
-local pres = fishingmod.DefaultUIColors().uiButtonPressed
-local masterX, masterY = 354, 224
+local back_ground = fishingmod.DefaultUIColors().ui_background
+local ui_text = fishingmod.DefaultUIColors().ui_text
+local button_not_selected = fishingmod.DefaultUIColors().ui_text_bg
+local ui_button_hovered = fishingmod.DefaultUIColors().ui_button_hovered
+local nopres = fishingmod.DefaultUIColors().ui_button_deselected
+local pres = fishingmod.DefaultUIColors().ui_button_pressed
+local master_x, master_y = 354, 224
 
 local PANEL = {} -- Main panel
 
 function PANEL:Init()
 	if fishingmod.ColorTable then
-		backGround = fishingmod.ColorTable.uiBackground or backGround
-		uiText = fishingmod.ColorTable.uiText or uiText
-		buttonNotSelected = fishingmod.ColorTable.uiTextBg or buttonNotSelected
-		uiButtonHovered = fishingmod.ColorTable.uiButtonHovered or uiButtonHovered
-		nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
-		pres = fishingmod.ColorTable.uiButtonPressed or pres
+		back_ground = fishingmod.ColorTable.ui_background or back_ground
+		ui_text = fishingmod.ColorTable.ui_text or ui_text
+		button_not_selected = fishingmod.ColorTable.ui_text_bg or button_not_selected
+		ui_button_hovered = fishingmod.ColorTable.ui_button_hovered or ui_button_hovered
+		nopres = fishingmod.ColorTable.ui_button_deselected or nopres
+		pres = fishingmod.ColorTable.ui_button_pressed or pres
 	end
 	self:MakePopup()
 	self:SetDeleteOnClose(false)
 	self:SetSizable(true)
 	self:SetTitle("Fishing Mod")
-	self.lblTitle:SetTextColor(uiText)
+	self.lblTitle:SetTextColor(ui_text)
 	self:ShowCloseButton(false)
-	self:SetSize(masterX, masterY)
+	self:SetSize(master_x, master_y)
 	self:Center()
 
 	self.baitshop = vgui.Create("Fishingmod:BaitShop", self)
@@ -145,14 +145,14 @@ function PANEL:Init()
 		xpx, xpy = self:GetSize()
 		upgradesbutton:SetSize((xpx - 6) / 3, 22)
 	end
-	upgradesbutton:SetTextColor(uiText)
+	upgradesbutton:SetTextColor(ui_text)
 	upgradesbutton.DoClick = function()
-		upgradesbutton:SetColor(uiText)
+		upgradesbutton:SetColor(ui_text)
 		baitsbutton:SetColor(nopres)
 		customizationbutton:SetColor(nopres)
 
-		baitsbutton:SetTextColor(buttonNotSelected)
-		customizationbutton:SetTextColor(buttonNotSelected)
+		baitsbutton:SetTextColor(button_not_selected)
+		customizationbutton:SetTextColor(button_not_selected)
 
 		upgradesbutton.selected = true
 		baitsbutton.selected = false
@@ -164,14 +164,14 @@ function PANEL:Init()
 	end
 	upgradesbutton.Paint = function(self, w, h)
 		if self.selected then
-			upgradesbutton:SetColor(uiText)
+			upgradesbutton:SetColor(ui_text)
 		elseif not self.selected then
-			upgradesbutton:SetColor(buttonNotSelected)
+			upgradesbutton:SetColor(button_not_selected)
 		end
 		if upgradesbutton:IsHovered() then
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		elseif upgradesbutton.selected then
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -186,14 +186,14 @@ function PANEL:Init()
 		baitsbutton:SetPos(3 + (xpx - 6) / 3, 24)
 	end
 	baitsbutton:SetText("Bait Shop")
-	baitsbutton:SetTextColor(buttonNotSelected)
+	baitsbutton:SetTextColor(button_not_selected)
 	baitsbutton.DoClick = function()
-		baitsbutton:SetColor(uiText)
+		baitsbutton:SetColor(ui_text)
 		upgradesbutton:SetColor(nopres)
 		customizationbutton:SetColor(nopres)
 
-		upgradesbutton:SetTextColor(buttonNotSelected)
-		customizationbutton:SetTextColor(buttonNotSelected)
+		upgradesbutton:SetTextColor(button_not_selected)
+		customizationbutton:SetTextColor(button_not_selected)
 
 		upgradesbutton.selected = false
 		baitsbutton.selected = true
@@ -205,14 +205,14 @@ function PANEL:Init()
 	end
 	baitsbutton.Paint = function(self, w, h)
 		if self.selected then
-			baitsbutton:SetColor(uiText)
+			baitsbutton:SetColor(ui_text)
 		elseif not self.selected then
-			baitsbutton:SetColor(buttonNotSelected)
+			baitsbutton:SetColor(button_not_selected)
 		end
 		if baitsbutton:IsHovered() then
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		elseif baitsbutton.selected then
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -237,14 +237,14 @@ function PANEL:Init()
 		end
 	end
 	customizationbutton:SetText("Customize")
-	customizationbutton:SetTextColor(buttonNotSelected)
+	customizationbutton:SetTextColor(button_not_selected)
 	customizationbutton.DoClick = function()
-		customizationbutton:SetColor(uiText)
+		customizationbutton:SetColor(ui_text)
 		upgradesbutton:SetColor(nopres)
 		baitsbutton:SetColor(nopres)
 
-		upgradesbutton:SetTextColor(buttonNotSelected)
-		baitsbutton:SetTextColor(buttonNotSelected)
+		upgradesbutton:SetTextColor(button_not_selected)
+		baitsbutton:SetTextColor(button_not_selected)
 
 		upgradesbutton.selected = false
 		baitsbutton.selected = false
@@ -257,14 +257,14 @@ function PANEL:Init()
 	end
 	customizationbutton.Paint = function(self, w, h)
 		if self.selected then
-			customizationbutton:SetColor(uiText)
+			customizationbutton:SetColor(ui_text)
 		elseif not self.selected then
-			customizationbutton:SetColor(buttonNotSelected)
+			customizationbutton:SetColor(button_not_selected)
 		end
 		if(customizationbutton:IsHovered()) then
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		elseif(customizationbutton.selected) then
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -273,8 +273,8 @@ function PANEL:Init()
 
 
 	function self:Paint()
-		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
-		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
+		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -283,7 +283,7 @@ function PANEL:Init()
 	closebutton.ButtonW = 60
 	closebutton:SetSize(closebutton.ButtonW, 18)
 	closebutton:SetText("Close")
-	closebutton:SetTextColor(uiText)
+	closebutton:SetTextColor(ui_text)
 	closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
 	closebutton.DoClick = function()
 		self:Close()
@@ -293,20 +293,20 @@ function PANEL:Init()
 		closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
 	end
 	closebutton.Paint = function(self, w, h)
-		self:GetParent().lblTitle:SetTextColor(uiText)
-		closebutton:SetTextColor(uiText)
+		self:GetParent().lblTitle:SetTextColor(ui_text)
+		closebutton:SetTextColor(ui_text)
 		if(closebutton:IsDown() ) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(closebutton:IsHovered()) then
-			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	
 	function self.baitshop:Paint()
-		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -330,15 +330,15 @@ function PANEL:Init()
 	self:SetPos(3, 46)
 	self:SetPadding(10)
 	function self:Paint()
-		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
-		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
+		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		self.money:SetTextColor(uiText)
+		self.money:SetTextColor(ui_text)
 		return true
 	end
 
 	self.money = vgui.Create("DLabel", self)
-	self.money:SetTextColor(uiText)
+	self.money:SetTextColor(ui_text)
 	self.money.Think = function(self) self:SetText("Money: " .. math.Round(LocalPlayer().fishingmod.money)) end
 	
 	self:AddItem(self.money)
@@ -433,12 +433,12 @@ function PANEL:Init()
 		x, y = self:GetParent():GetSize()
 		self:SetSize(x - 6, y - 3 - 46)
 		if fishingmod.ColorTable then
-			backGround = fishingmod.ColorTable.uiBackground or backGround
-			uiText = fishingmod.ColorTable.uiText or uiText
-			buttonNotSelected = fishingmod.ColorTable.uiTextBg or buttonNotSelected
-			uiButtonHovered = fishingmod.ColorTable.uiButtonHovered or uiButtonHovered
-			nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
-			pres = fishingmod.ColorTable.uiButtonPressed or pres
+			back_ground = fishingmod.ColorTable.ui_background or back_ground
+			ui_text = fishingmod.ColorTable.ui_text or ui_text
+			button_not_selected = fishingmod.ColorTable.ui_text_bg or button_not_selected
+			ui_button_hovered = fishingmod.ColorTable.ui_button_hovered or ui_button_hovered
+			nopres = fishingmod.ColorTable.ui_button_deselected or nopres
+			pres = fishingmod.ColorTable.ui_button_pressed or pres
 		else
 			fishingmod.ColorTable = fishingmod.DefaultUIColors()
 		end
@@ -447,11 +447,11 @@ function PANEL:Init()
 	local savebutton = vgui.Create("DButton", self)
 	savebutton:SetPos(10, 50)
 	savebutton:SetSize(120, 30)
-	savebutton:SetTextColor(uiText)
+	savebutton:SetTextColor(ui_text)
 	savebutton:SetText("Save")
 	savebutton.Paint = function(self, w, h)
-		savebutton:SetTextColor(uiText)
-		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		savebutton:SetTextColor(ui_text)
+		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
@@ -464,11 +464,11 @@ function PANEL:Init()
 	local resetbutton = vgui.Create("DButton", self)
 	resetbutton:SetPos(10, 90)
 	resetbutton:SetSize(120, 30)
-	resetbutton:SetTextColor(uiText)
+	resetbutton:SetTextColor(ui_text)
 	resetbutton:SetText("Reset")
 	resetbutton.Paint = function(self, w, h)
-		resetbutton:SetTextColor(uiText)
-		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		resetbutton:SetTextColor(ui_text)
+		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
@@ -491,13 +491,13 @@ function PANEL:Init()
 		end
 	end
 	combobox.Paint = function(self, w, h)
-		combobox:SetTextColor(uiText)
+		combobox:SetTextColor(ui_text)
 		if(combobox:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(combobox:IsHovered()) then
-			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
@@ -522,30 +522,30 @@ function PANEL:Init()
 	end
 	
 	function savebutton:Paint(w, h)
-		savebutton:SetTextColor(uiText)
+		savebutton:SetTextColor(ui_text)
 		if(savebutton:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(savebutton:IsHovered()) then
-			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	function resetbutton:Paint(w, h)
-		resetbutton:SetTextColor(uiText)
+		resetbutton:SetTextColor(ui_text)
 		if(resetbutton:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(resetbutton:IsHovered()) then
-			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
-			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	function self:Paint()
-		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
-		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
+		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -583,11 +583,11 @@ function PANEL:Init()
 	end
 	
 	self.rightlabel = vgui.Create("DLabel", self)
-	self.rightlabel:SetTextColor(uiText)
+	self.rightlabel:SetTextColor(ui_text)
 	self.rightlabel:SetSize(100, 30)
 	
 	self.leftlabel = vgui.Create("DLabel", self)
-	self.leftlabel:SetTextColor(uiText)
+	self.leftlabel:SetTextColor(ui_text)
 	self.leftlabel:SetSize(100, 30)
 	
 	self.left:Dock(LEFT)
@@ -597,35 +597,35 @@ function PANEL:Init()
 	local selfleft = self.left
 	function self.left:Paint() -- 'sell' skill button
 		surface.SetFont("DebugFixed")
-		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
+		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
 		if(selfleft:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(selfleft:IsHovered()) then
-			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
 			surface.SetDrawColor(0, 0, 0, 100)
 		end
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		surface.SetDrawColor(uiText)
-		surface.SetMaterial(FishingMod_spriteMinus)
+		surface.SetDrawColor(ui_text)
+		surface.SetMaterial(fishingmod_sprite_minus)
 		surface.DrawTexturedRect(1, 1, self:GetWide() - 2, self:GetTall() - 2)
 		return true
 	end
 	local selfright = self.right
 	function self.right:Paint() -- buy skill button
 		surface.SetFont("DebugFixed")
-		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
+		surface.SetTextColor(ui_text.r, ui_text.g, ui_text.b, ui_text.a)
 
 		if(selfright:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(selfright:IsHovered()) then
-			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
+			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
 			surface.SetDrawColor(0, 0, 0, 100)
 		end
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		surface.SetDrawColor(uiText)
-		surface.SetMaterial(FishingMod_spritePlus)
+		surface.SetDrawColor(ui_text)
+		surface.SetMaterial(fishingmod_sprite_plus)
 		surface.DrawTexturedRect(1, 1, self:GetWide() - 2, self:GetTall() - 2)
 		return true
 	end
@@ -642,8 +642,8 @@ end
 
 function PANEL:Think()
 	if not self.set then return end
-	self.rightlabel:SetTextColor(uiText)
-	self.leftlabel:SetTextColor(uiText)
+	self.rightlabel:SetTextColor(ui_text)
+	self.leftlabel:SetTextColor(ui_text)
 	self.rightlabel:SetText(LocalPlayer().fishingmod[self.type])
 end
 

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -461,21 +461,21 @@ function PANEL:Init()
 			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been saved!")
 		end
 	end
-	local resetbutton = vgui.Create("DButton", self)
-	resetbutton:SetPos(10, 90)
-	resetbutton:SetSize(120, 30)
-	resetbutton:SetTextColor(ui_text)
-	resetbutton:SetText("Reset")
-	resetbutton.Paint = function(self, w, h)
-		resetbutton:SetTextColor(ui_text)
+	local defaultsbutton = vgui.Create("DButton", self)
+	defaultsbutton:SetPos(10, 90)
+	defaultsbutton:SetSize(120, 30)
+	defaultsbutton:SetTextColor(ui_text)
+	defaultsbutton:SetText("Defaults")
+	defaultsbutton.Paint = function(self, w, h)
+		defaultsbutton:SetTextColor(ui_text)
 		surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	resetbutton.DoClick = function()
+	defaultsbutton.DoClick = function()
 		if fishingmod.DefaultUIColors then
 			fishingmod.ColorTable = fishingmod.DefaultUIColors()
-			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been reset!")
+			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been set to default!")
 		end
 	end
 	
@@ -532,11 +532,11 @@ function PANEL:Init()
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
-	function resetbutton:Paint(w, h)
-		resetbutton:SetTextColor(ui_text)
-		if(resetbutton:IsDown()) then
+	function defaultsbutton:Paint(w, h)
+		defaultsbutton:SetTextColor(ui_text)
+		if(defaultsbutton:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(resetbutton:IsHovered()) then
+		elseif(defaultsbutton:IsHovered()) then
 			surface.SetDrawColor(ui_button_hovered.r, ui_button_hovered.g, ui_button_hovered.b, ui_button_hovered.a)
 		else
 			surface.SetDrawColor(back_ground.r, back_ground.g, back_ground.b, back_ground.a)
@@ -554,7 +554,7 @@ function PANEL:Init()
 		colormixer:SetPos(math.min(120 + 20, math.max(x - 150, 10)), 10)
 		combobox:SetSize(math.min(120, x - 170), math.min(30, y - 20))
 		savebutton:SetSize(math.min(120, x - 170), math.min(30, y - 60))
-		resetbutton:SetSize(math.min(120, x - 170), math.min(30, y - 100))
+		defaultsbutton:SetSize(math.min(120, x - 170), math.min(30, y - 100))
 	end
 end
 

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -364,6 +364,10 @@ function PANEL:Init()
 	self.force = vgui.Create("Fishingmod:UpgradeButton", self)
 	self.force:SetType("Hook Force:", "force", "hook_force", fishingmod.HookForcePrice)
 	self:AddItem(self.force)
+
+	self.seagull_deter = vgui.Create("Fishingmod:UpgradeButton", self)
+	self.seagull_deter:SetType("Seagull Deterring:", "seagull_deter", "seagull_deter", fishingmod.SeagullDeterPrice)
+	self:AddItem(self.seagull_deter)
 end
 
 vgui.Register("Fishingmod:Upgrade", PANEL, "DPanelList")

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -105,15 +105,13 @@ local masterX, masterY = 354, 224
 local PANEL = {} -- Main panel
 
 function PANEL:Init()
-	if fishingmod then
-		if fishingmod.ColorTable then
-			bg = fishingmod.ColorTable.uiBackground or bg
-			sel = fishingmod.ColorTable.uiText or sel
-			nosel = fishingmod.ColorTable.uiTextBg or nosel
-			hov = fishingmod.ColorTable.uiButtonHovered or hov
-			nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
-			pres = fishingmod.ColorTable.uiButtonPressed or pres
-		end
+	if fishingmod.ColorTable then
+		bg = fishingmod.ColorTable.uiBackground or bg
+		sel = fishingmod.ColorTable.uiText or sel
+		nosel = fishingmod.ColorTable.uiTextBg or nosel
+		hov = fishingmod.ColorTable.uiButtonHovered or hov
+		nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
+		pres = fishingmod.ColorTable.uiButtonPressed or pres
 	end
 	self:MakePopup()
 	self:SetDeleteOnClose(false)

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -47,34 +47,34 @@ function fishingmod.SaveUIColors()
         file.CreateDir(fishingmodDataPath)
 	end
 	local newData = {}
-	local t = fishingmod.DefaultUIColors()
+	local returnData = fishingmod.DefaultUIColors()
 	if fishingmod.ColorTable then
 		for k, v in pairs(fishingmod.ColorTable) do
 			newData[k] = tostring(v.r) .. " " .. tostring(v.g) .. " " .. tostring(v.b) .. " ".. tostring(v.a)
 		end
-		table.Merge(t, newData)
+		table.Merge(returnData, newData)
 	end
-	file.Write(fishingmodDataPath .. fishingmodDataFileName, util.TableToJSON(t, false))
+	file.Write(fishingmodDataPath .. fishingmodDataFileName, util.TableToJSON(returnData, false))
 	newData = nil
 end
 function fishingmod.LoadUIColors()
 	local tempCol = Color(0, 0, 0, 72)
 	if file.Exists(fishingmodDataPath, "DATA") then
 		if file.Exists(fishingmodDataPath .. fishingmodDataFileName, "DATA") then
-			local t_ = util.JSONToTable(file.Read(fishingmodDataPath .. fishingmodDataFileName, "DATA"))
-			local t = fishingmod.DefaultUIColors()
-			if t_ then
-				for k, v in pairs(t_) do
+			local tempData = util.JSONToTable(file.Read(fishingmodDataPath .. fishingmodDataFileName, "DATA"))
+			local returnData = fishingmod.DefaultUIColors()
+			if tempData then
+				for k, v in pairs(tempData) do
 					if k and v then
 						if #tostring(k) < 4 then return end
 						if #tostring(v) < 4 then return end
-						t_[k] = string.ToColor(v) or tempCol
+						tempData[k] = string.ToColor(v) or tempCol
 					end
 				end
-				table.Merge(t, t_)
+				table.Merge(returnData, tempData)
 			end
-			t_ = {}
-			return t
+			tempData = {}
+			return returnData
 		else
 			return fishingmod.DefaultUIColors() -- return defaults if the file does not exist
 		end
@@ -94,10 +94,10 @@ local FishingMod_spritePlus, a = Material("sprites/key_12")
 FishingMod_spriteMinus:SetInt("$flags", 2097152)
 FishingMod_spritePlus:SetInt("$flags", 2097152)
 
-local bg = fishingmod.DefaultUIColors().uiBackground
-local sel = fishingmod.DefaultUIColors().uiText
-local nosel = fishingmod.DefaultUIColors().uiTextBg
-local hov = fishingmod.DefaultUIColors().uiButtonHovered
+local backGround = fishingmod.DefaultUIColors().uiBackground
+local uiText = fishingmod.DefaultUIColors().uiText
+local buttonNotSelected = fishingmod.DefaultUIColors().uiTextBg
+local uiButtonHovered = fishingmod.DefaultUIColors().uiButtonHovered
 local nopres = fishingmod.DefaultUIColors().uiButtonDeSelected
 local pres = fishingmod.DefaultUIColors().uiButtonPressed
 local masterX, masterY = 354, 224
@@ -106,10 +106,10 @@ local PANEL = {} -- Main panel
 
 function PANEL:Init()
 	if fishingmod.ColorTable then
-		bg = fishingmod.ColorTable.uiBackground or bg
-		sel = fishingmod.ColorTable.uiText or sel
-		nosel = fishingmod.ColorTable.uiTextBg or nosel
-		hov = fishingmod.ColorTable.uiButtonHovered or hov
+		backGround = fishingmod.ColorTable.uiBackground or backGround
+		uiText = fishingmod.ColorTable.uiText or uiText
+		buttonNotSelected = fishingmod.ColorTable.uiTextBg or buttonNotSelected
+		uiButtonHovered = fishingmod.ColorTable.uiButtonHovered or uiButtonHovered
 		nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
 		pres = fishingmod.ColorTable.uiButtonPressed or pres
 	end
@@ -117,7 +117,7 @@ function PANEL:Init()
 	self:SetDeleteOnClose(false)
 	self:SetSizable(true)
 	self:SetTitle("Fishing Mod")
-	self.lblTitle:SetTextColor(sel)
+	self.lblTitle:SetTextColor(uiText)
 	self:ShowCloseButton(false)
 	self:SetSize(masterX, masterY)
 	self:Center()
@@ -134,10 +134,10 @@ function PANEL:Init()
 
 	local upgradesbutton = vgui.Create("DButton", self) -- upgrades
 	local baitsbutton = vgui.Create("DButton", self) -- baits shop
-	local cus = vgui.Create("DButton", self) -- customization tab
+	local customizationbutton = vgui.Create("DButton", self) -- customization tab
 
-	upgradesbutton.sel = true
-	baitsbutton.sel = false
+	upgradesbutton.selected = true
+	baitsbutton.selected = false
 	upgradesbutton:SetPos(3, 24)
 	upgradesbutton:SetSize((xpx - 6) / 3, 22)
 	upgradesbutton:SetText("Upgrades")
@@ -145,33 +145,33 @@ function PANEL:Init()
 		xpx, xpy = self:GetSize()
 		upgradesbutton:SetSize((xpx - 6) / 3, 22)
 	end
-	upgradesbutton:SetTextColor(sel)
+	upgradesbutton:SetTextColor(uiText)
 	upgradesbutton.DoClick = function()
-		upgradesbutton:SetColor(sel)
+		upgradesbutton:SetColor(uiText)
 		baitsbutton:SetColor(nopres)
-		cus:SetColor(nopres)
+		customizationbutton:SetColor(nopres)
 
-		baitsbutton:SetTextColor(nosel)
-		cus:SetTextColor(nosel)
+		baitsbutton:SetTextColor(buttonNotSelected)
+		customizationbutton:SetTextColor(buttonNotSelected)
 
-		upgradesbutton.sel = true
-		baitsbutton.sel = false
-		cus.sel = false
+		upgradesbutton.selected = true
+		baitsbutton.selected = false
+		customizationbutton.selected = false
 
 		self.customization:Hide()
 		self.upgrade:Show()
 		self.baitshop:Hide()
 	end
 	upgradesbutton.Paint = function(self, w, h)
-		if self.sel then
-			upgradesbutton:SetColor(sel)
-		elseif not self.sel then
-			upgradesbutton:SetColor(nosel)
+		if self.selected then
+			upgradesbutton:SetColor(uiText)
+		elseif not self.selected then
+			upgradesbutton:SetColor(buttonNotSelected)
 		end
-		if(upgradesbutton:IsHovered()) then
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-		elseif(upgradesbutton.sel) then
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		if upgradesbutton:IsHovered() then
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		elseif upgradesbutton.selected then
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -186,33 +186,33 @@ function PANEL:Init()
 		baitsbutton:SetPos(3 + (xpx - 6) / 3, 24)
 	end
 	baitsbutton:SetText("Bait Shop")
-	baitsbutton:SetTextColor(nosel)
+	baitsbutton:SetTextColor(buttonNotSelected)
 	baitsbutton.DoClick = function()
-		baitsbutton:SetColor(sel)
+		baitsbutton:SetColor(uiText)
 		upgradesbutton:SetColor(nopres)
-		cus:SetColor(nopres)
+		customizationbutton:SetColor(nopres)
 
-		upgradesbutton:SetTextColor(nosel)
-		cus:SetTextColor(nosel)
+		upgradesbutton:SetTextColor(buttonNotSelected)
+		customizationbutton:SetTextColor(buttonNotSelected)
 
-		upgradesbutton.sel = false
-		baitsbutton.sel = true
-		cus.sel = false
+		upgradesbutton.selected = false
+		baitsbutton.selected = true
+		customizationbutton.selected = false
 
 		self.customization:Hide()
 		self.upgrade:Hide()
 		self.baitshop:Show()
 	end
 	baitsbutton.Paint = function(self, w, h)
-		if self.sel then
-			baitsbutton:SetColor(sel)
-		elseif not self.sel then
-			baitsbutton:SetColor(nosel)
+		if self.selected then
+			baitsbutton:SetColor(uiText)
+		elseif not self.selected then
+			baitsbutton:SetColor(buttonNotSelected)
 		end
-		if(baitsbutton:IsHovered()) then
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-		elseif(baitsbutton.sel) then
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		if baitsbutton:IsHovered() then
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		elseif baitsbutton.selected then
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -220,51 +220,51 @@ function PANEL:Init()
 	end
 
 
-	cus:SetPos(3 + (xpx - 6) / 3, 24) -- baits shop start of conf
-	cus:SetSize((xpx - 6) / 3, 22)
+	customizationbutton:SetPos(3 + (xpx - 6) / 3, 24) -- baits shop start of conf
+	customizationbutton:SetSize((xpx - 6) / 3, 22)
 	
-	function cus.Think()
+	function customizationbutton.Think()
 		xpx, xpy = self:GetSize()
-		if(xpx % 3 == 2) then
-			cus:SetSize(math.Round((xpx - 6) / 3) + 1 , 22)
-			cus:SetPos(2 + (xpx - 6) / 3 * 2 , 24)
-		elseif(xpx % 3 == 1 ) then
-			cus:SetSize(math.Round((xpx - 6) / 3) + 1, 22)
-			cus:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
+		if xpx % 3 == 2 then
+			customizationbutton:SetSize(math.Round((xpx - 6) / 3) + 1 , 22)
+			customizationbutton:SetPos(2 + (xpx - 6) / 3 * 2 , 24)
+		elseif xpx % 3 == 1  then
+			customizationbutton:SetSize(math.Round((xpx - 6) / 3) + 1, 22)
+			customizationbutton:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
 		else
-			cus:SetSize(math.Round((xpx - 6) / 3) , 22)
-			cus:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
+			customizationbutton:SetSize(math.Round((xpx - 6) / 3) , 22)
+			customizationbutton:SetPos(3 + (xpx - 6) / 3 * 2 , 24)
 		end
 	end
-	cus:SetText("Customize")
-	cus:SetTextColor(nosel)
-	cus.DoClick = function()
-		cus:SetColor(sel)
+	customizationbutton:SetText("Customize")
+	customizationbutton:SetTextColor(buttonNotSelected)
+	customizationbutton.DoClick = function()
+		customizationbutton:SetColor(uiText)
 		upgradesbutton:SetColor(nopres)
 		baitsbutton:SetColor(nopres)
 
-		upgradesbutton:SetTextColor(nosel)
-		baitsbutton:SetTextColor(nosel)
+		upgradesbutton:SetTextColor(buttonNotSelected)
+		baitsbutton:SetTextColor(buttonNotSelected)
 
-		upgradesbutton.sel = false
-		baitsbutton.sel = false
-		cus.sel = true
+		upgradesbutton.selected = false
+		baitsbutton.selected = false
+		customizationbutton.selected = true
 
 		self.customization:Show()
 		self.upgrade:Hide()
 		self.baitshop:Hide()
 
 	end
-	cus.Paint = function(self, w, h)
-		if self.sel then
-			cus:SetColor(sel)
-		elseif not self.sel then
-			cus:SetColor(nosel)
+	customizationbutton.Paint = function(self, w, h)
+		if self.selected then
+			customizationbutton:SetColor(uiText)
+		elseif not self.selected then
+			customizationbutton:SetColor(buttonNotSelected)
 		end
-		if(cus:IsHovered()) then
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
-		elseif(cus.sel) then
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		if(customizationbutton:IsHovered()) then
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
+		elseif(customizationbutton.selected) then
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		else
 			surface.SetDrawColor(nopres.r, nopres.g, nopres.b, nopres.a)
 		end
@@ -273,8 +273,8 @@ function PANEL:Init()
 
 
 	function self:Paint()
-		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
-		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
+		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -283,7 +283,7 @@ function PANEL:Init()
 	closebutton.ButtonW = 60
 	closebutton:SetSize(closebutton.ButtonW, 18)
 	closebutton:SetText("Close")
-	closebutton:SetTextColor(sel)
+	closebutton:SetTextColor(uiText)
 	closebutton:SetPos(x - closebutton.ButtonW - 3, 3)
 	closebutton.DoClick = function()
 		self:Close()
@@ -293,20 +293,20 @@ function PANEL:Init()
 		closebutton:SetSize(math.min(closebutton.ButtonW, x - 6) , 18 )
 	end
 	closebutton.Paint = function(self, w, h)
-		self:GetParent().lblTitle:SetTextColor(sel)
-		closebutton:SetTextColor(sel)
+		self:GetParent().lblTitle:SetTextColor(uiText)
+		closebutton:SetTextColor(uiText)
 		if(closebutton:IsDown() ) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(closebutton:IsHovered()) then
-			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 		else
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	
 	function self.baitshop:Paint()
-		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
@@ -330,15 +330,15 @@ function PANEL:Init()
 	self:SetPos(3, 46)
 	self:SetPadding(10)
 	function self:Paint()
-		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
-		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
+		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		self.money:SetTextColor(sel)
+		self.money:SetTextColor(uiText)
 		return true
 	end
 
 	self.money = vgui.Create("DLabel", self)
-	self.money:SetTextColor(sel)
+	self.money:SetTextColor(uiText)
 	self.money.Think = function(self) self:SetText("Money: " .. math.Round(LocalPlayer().fishingmod.money)) end
 	
 	self:AddItem(self.money)
@@ -407,7 +407,7 @@ function PANEL:Init()
 		fishingmod.BaitTable[data.name].icon = icon
 		
 		if(level < data.levelrequired) then
-			icon:Setnosel(true)
+			icon:SetGray(true)
 		else
 			icon.DoClick = function()
 				RunConsoleCommand("fishing_mod_buy_bait", data.name)
@@ -433,10 +433,10 @@ function PANEL:Init()
 		x, y = self:GetParent():GetSize()
 		self:SetSize(x - 6, y - 3 - 46)
 		if fishingmod.ColorTable then
-			bg = fishingmod.ColorTable.uiBackground or bg
-			sel = fishingmod.ColorTable.uiText or sel
-			nosel = fishingmod.ColorTable.uiTextBg or nosel
-			hov = fishingmod.ColorTable.uiButtonHovered or hov
+			backGround = fishingmod.ColorTable.uiBackground or backGround
+			uiText = fishingmod.ColorTable.uiText or uiText
+			buttonNotSelected = fishingmod.ColorTable.uiTextBg or buttonNotSelected
+			uiButtonHovered = fishingmod.ColorTable.uiButtonHovered or uiButtonHovered
 			nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
 			pres = fishingmod.ColorTable.uiButtonPressed or pres
 		else
@@ -444,117 +444,117 @@ function PANEL:Init()
 		end
 	end
 
-	local saveb = vgui.Create("DButton", self)
-	saveb:SetPos(10, 50)
-	saveb:SetSize(120, 30)
-	saveb:SetTextColor(sel)
-	saveb:SetText("Save")
-	saveb.Paint = function(self, w, h)
-		saveb:SetTextColor(sel)
-		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+	local savebutton = vgui.Create("DButton", self)
+	savebutton:SetPos(10, 50)
+	savebutton:SetSize(120, 30)
+	savebutton:SetTextColor(uiText)
+	savebutton:SetText("Save")
+	savebutton.Paint = function(self, w, h)
+		savebutton:SetTextColor(uiText)
+		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	saveb.DoClick = function()
+	savebutton.DoClick = function()
 		if fishingmod.SaveUIColors then
 			fishingmod.SaveUIColors()
-			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been Saved!")
+			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been saved!")
 		end
 	end
-	local Reset = vgui.Create("DButton", self)
-	Reset:SetPos(10, 90)
-	Reset:SetSize(120, 30)
-	Reset:SetTextColor(sel)
-	Reset:SetText("Reset")
-	Reset.Paint = function(self, w, h)
-		Reset:SetTextColor(sel)
-		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+	local resetbutton = vgui.Create("DButton", self)
+	resetbutton:SetPos(10, 90)
+	resetbutton:SetSize(120, 30)
+	resetbutton:SetTextColor(uiText)
+	resetbutton:SetText("Reset")
+	resetbutton.Paint = function(self, w, h)
+		resetbutton:SetTextColor(uiText)
+		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		surface.DrawRect(0, 0, w, h)
 	end
 
-	Reset.DoClick = function()
+	resetbutton.DoClick = function()
 		if fishingmod.DefaultUIColors then
 			fishingmod.ColorTable = fishingmod.DefaultUIColors()
-			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been Reset!")
+			chat.AddText(Color(0, 255, 0, 255), "[Fishing Mod]", Color(255, 255, 255), ": Colors have been reset!")
 		end
 	end
 	
-	local cbox = vgui.Create("DComboBox", self )
-	cbox:SetPos(10, 10)
-	cbox:SetSize(120, 30)
-	cbox:SetValue("Select element")
+	local combobox = vgui.Create("DComboBox", self )
+	combobox:SetPos(10, 10)
+	combobox:SetSize(120, 30)
+	combobox:SetValue("Select element")
 	if fishingmod.ColorTable then
 		if fishingmod.LoadUIColors then
 			for k, v in pairs(fishingmod.LoadUIColors()) do
-				cbox:AddChoice(translation[k])
+				combobox:AddChoice(translation[k])
 			end
 		end
 	end
-	cbox.Paint = function(self, w, h)
-		cbox:SetTextColor(sel)
-		if(cbox:IsDown()) then
+	combobox.Paint = function(self, w, h)
+		combobox:SetTextColor(uiText)
+		if(combobox:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(cbox:IsHovered()) then
-			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+		elseif(combobox:IsHovered()) then
+			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 		else
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
-	local dcm = vgui.Create( "DColorMixer", self)
+	local colormixer = vgui.Create( "DColorMixer", self)
 	local x, y = self:GetSize()
-	dcm:SetPos(120 + 20, 10)
-	dcm:SetWangs(true)
-	dcm:SetPalette(false)
-	dcm:SetSize(x - 10 - 120 - 20, y - 20)
-	function dcm:ValueChanged(col)
+	colormixer:SetPos(120 + 20, 10)
+	colormixer:SetWangs(true)
+	colormixer:SetPalette(false)
+	colormixer:SetSize(x - 10 - 120 - 20, y - 20)
+	function colormixer:ValueChanged(col)
 		if editable and editable != "" and fishingmod.DefaultUIColors()[editable] then
 			fishingmod.ColorTable[editable] = Color(col.r, col.g, col.b, col.a)
 		end
 	end
-	function cbox.OnSelect(self, val, str)
+	function combobox.OnSelect(self, val, str)
 		if type(str)=="string" and str != "" then
 			editable = translation[str]
 			if fishingmod.ColorTable[editable] then
-				dcm:SetColor(fishingmod.ColorTable[editable])
+				colormixer:SetColor(fishingmod.ColorTable[editable])
 			end
 		end
 	end
 	
-	function saveb:Paint(w, h)
-		saveb:SetTextColor(sel)
-		if(saveb:IsDown()) then
+	function savebutton:Paint(w, h)
+		savebutton:SetTextColor(uiText)
+		if(savebutton:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(saveb:IsHovered()) then
-			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+		elseif(savebutton:IsHovered()) then
+			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 		else
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
-	function Reset:Paint(w, h)
-		Reset:SetTextColor(sel)
-		if(Reset:IsDown()) then
+	function resetbutton:Paint(w, h)
+		resetbutton:SetTextColor(uiText)
+		if(resetbutton:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
-		elseif(Reset:IsHovered()) then
-			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+		elseif(resetbutton:IsHovered()) then
+			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 		else
-			surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+			surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		end
 		surface.DrawRect(0, 0, w, h)
 	end
 	function self:Paint()
-		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
-		surface.SetDrawColor(bg.r, bg.g, bg.b, bg.a)
+		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
+		surface.SetDrawColor(backGround.r, backGround.g, backGround.b, backGround.a)
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
 		return true
 	end
 	function self:OnSizeChanged(x, y)
-		dcm:SetSize(math.max(math.min(140, x - 20), x - 10 - 120 - 20), y - 20)
-		dcm:SetPos(math.min(120 + 20, math.max(x - 150, 10)), 10)
-		cbox:SetSize(math.min(120, x - 170), math.min(30, y - 20))
-		saveb:SetSize(math.min(120, x - 170), math.min(30, y - 60))
-		Reset:SetSize(math.min(120, x - 170), math.min(30, y - 100))
+		colormixer:SetSize(math.max(math.min(140, x - 20), x - 10 - 120 - 20), y - 20)
+		colormixer:SetPos(math.min(120 + 20, math.max(x - 150, 10)), 10)
+		combobox:SetSize(math.min(120, x - 170), math.min(30, y - 20))
+		savebutton:SetSize(math.min(120, x - 170), math.min(30, y - 60))
+		resetbutton:SetSize(math.min(120, x - 170), math.min(30, y - 100))
 	end
 end
 
@@ -583,11 +583,11 @@ function PANEL:Init()
 	end
 	
 	self.rightlabel = vgui.Create("DLabel", self)
-	self.rightlabel:SetTextColor(sel)
+	self.rightlabel:SetTextColor(uiText)
 	self.rightlabel:SetSize(100, 30)
 	
 	self.leftlabel = vgui.Create("DLabel", self)
-	self.leftlabel:SetTextColor(sel)
+	self.leftlabel:SetTextColor(uiText)
 	self.leftlabel:SetSize(100, 30)
 	
 	self.left:Dock(LEFT)
@@ -597,16 +597,16 @@ function PANEL:Init()
 	local selfleft = self.left
 	function self.left:Paint() -- 'sell' skill button
 		surface.SetFont("DebugFixed")
-		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
+		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
 		if(selfleft:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(selfleft:IsHovered()) then
-			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 		else
 			surface.SetDrawColor(0, 0, 0, 100)
 		end
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		surface.SetDrawColor(sel)
+		surface.SetDrawColor(uiText)
 		surface.SetMaterial(FishingMod_spriteMinus)
 		surface.DrawTexturedRect(1, 1, self:GetWide() - 2, self:GetTall() - 2)
 		return true
@@ -614,17 +614,17 @@ function PANEL:Init()
 	local selfright = self.right
 	function self.right:Paint() -- buy skill button
 		surface.SetFont("DebugFixed")
-		surface.SetTextColor(sel.r, sel.g, sel.b, sel.a)
+		surface.SetTextColor(uiText.r, uiText.g, uiText.b, uiText.a)
 
 		if(selfright:IsDown()) then
 			surface.SetDrawColor(pres.r, pres.g, pres.b, pres.a)
 		elseif(selfright:IsHovered()) then
-			surface.SetDrawColor(hov.r, hov.g, hov.b, hov.a)
+			surface.SetDrawColor(uiButtonHovered.r, uiButtonHovered.g, uiButtonHovered.b, uiButtonHovered.a)
 		else
 			surface.SetDrawColor(0, 0, 0, 100)
 		end
 		surface.DrawRect(0, 0, self:GetWide(), self:GetTall())
-		surface.SetDrawColor(sel)
+		surface.SetDrawColor(uiText)
 		surface.SetMaterial(FishingMod_spritePlus)
 		surface.DrawTexturedRect(1, 1, self:GetWide() - 2, self:GetTall() - 2)
 		return true
@@ -642,8 +642,8 @@ end
 
 function PANEL:Think()
 	if not self.set then return end
-	self.rightlabel:SetTextColor(sel)
-	self.leftlabel:SetTextColor(sel)
+	self.rightlabel:SetTextColor(uiText)
+	self.leftlabel:SetTextColor(uiText)
 	self.rightlabel:SetText(LocalPlayer().fishingmod[self.type])
 end
 
@@ -661,8 +661,8 @@ function PANEL:SetSale(multiplier)
 	self.percent = math.Round((multiplier * - 1 + 1) * 100)
 end
 
-function PANEL:Setnosel(bool)
-	self.nosel = bool
+function PANEL:SetGray(bool)
+	self.Grey = bool
 end
 
 function PANEL:PaintOver(w, h)
@@ -670,7 +670,7 @@ function PANEL:PaintOver(w, h)
 
 	draw.SimpleText( self.percent.."% OFF", "DermaDefault", 5, 3, color_black, TEXT_ALIGN_LEFT, TEXT_ALIGN_LEFT)
 	draw.SimpleText( self.percent.."% OFF", "DermaDefault", 4, 2, HSVToColor(math.Clamp(self.percent + 40, 0, 160), 1, 1), TEXT_ALIGN_LEFT, TEXT_ALIGN_LEFT)
-	if self.nosel then draw.RoundedBox( 6, 0, 0, 58, 58, Color( 100, 100, 100, 200 ) ) end
+	if self.Grey then draw.RoundedBox( 6, 0, 0, 58, 58, Color( 100, 100, 100, 200 ) ) end
 end
 
 vgui.Register("Fishingmod:SpawnIcon", PANEL, "SpawnIcon")

--- a/lua/fishing_mod/cl_shop_menu.lua
+++ b/lua/fishing_mod/cl_shop_menu.lua
@@ -94,12 +94,12 @@ local FishingMod_spritePlus, a = Material("sprites/key_12")
 FishingMod_spriteMinus:SetInt("$flags", 2097152)
 FishingMod_spritePlus:SetInt("$flags", 2097152)
 
-local bg = fishingmod.ColorTable.uiBackground
-local sel = fishingmod.ColorTable.uiText
-local nosel = fishingmod.ColorTable.uiTextBg
-local hov = fishingmod.ColorTable.uiButtonHovered
-local nopres = fishingmod.ColorTable.uiButtonDeSelected
-local pres = fishingmod.ColorTable.uiButtonPressed
+local bg = fishingmod.DefaultUIColors().uiBackground
+local sel = fishingmod.DefaultUIColors().uiText
+local nosel = fishingmod.DefaultUIColors().uiTextBg
+local hov = fishingmod.DefaultUIColors().uiButtonHovered
+local nopres = fishingmod.DefaultUIColors().uiButtonDeSelected
+local pres = fishingmod.DefaultUIColors().uiButtonPressed
 local masterX, masterY = 354, 224
 
 local PANEL = {} -- Main panel
@@ -107,12 +107,12 @@ local PANEL = {} -- Main panel
 function PANEL:Init()
 	if fishingmod then
 		if fishingmod.ColorTable then
-			bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
-			sel = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
-			nosel = fishingmod.ColorTable.uiTextBg or fishingmod.DefaultUIColors().uiTextBg
-			hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
-			nopres = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
-			pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
+			bg = fishingmod.ColorTable.uiBackground or bg
+			sel = fishingmod.ColorTable.uiText or sel
+			nosel = fishingmod.ColorTable.uiTextBg or nosel
+			hov = fishingmod.ColorTable.uiButtonHovered or hov
+			nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
+			pres = fishingmod.ColorTable.uiButtonPressed or pres
 		end
 	end
 	self:MakePopup()
@@ -434,17 +434,15 @@ function PANEL:Init()
 	function self:Think()
 		x, y = self:GetParent():GetSize()
 		self:SetSize(x - 6, y - 3 - 46)
-		if fishingmod then
-			if fishingmod.ColorTable then
-				bg = fishingmod.ColorTable.uiBackground or fishingmod.DefaultUIColors().uiBackground
-				sel = fishingmod.ColorTable.uiText or fishingmod.DefaultUIColors().uiText
-				nosel = fishingmod.ColorTable.uiTextBg or fishingmod.DefaultUIColors().uiTextBg
-				hov = fishingmod.ColorTable.uiButtonHovered or fishingmod.DefaultUIColors().uiButtonHovered
-				nopres = fishingmod.ColorTable.uiButtonDeSelected or fishingmod.DefaultUIColors().uiButtonDeSelected
-				pres = fishingmod.ColorTable.uiButtonPressed or fishingmod.DefaultUIColors().uiButtonPressed
-			else
-				fishingmod.ColorTable = fishingmod.DefaultUIColors()
-			end
+		if fishingmod.ColorTable then
+			bg = fishingmod.ColorTable.uiBackground or bg
+			sel = fishingmod.ColorTable.uiText or sel
+			nosel = fishingmod.ColorTable.uiTextBg or nosel
+			hov = fishingmod.ColorTable.uiButtonHovered or hov
+			nopres = fishingmod.ColorTable.uiButtonDeSelected or nopres
+			pres = fishingmod.ColorTable.uiButtonPressed or pres
+		else
+			fishingmod.ColorTable = fishingmod.DefaultUIColors()
 		end
 	end
 

--- a/lua/fishing_mod/sh_init.lua
+++ b/lua/fishing_mod/sh_init.lua
@@ -10,6 +10,8 @@ fishingmod.MaxReelSpeed = 100
 
 fishingmod.HookForcePrice = 600
 
+fishingmod.SeagullDeterPrice = 800
+
 local PLAYER = FindMetaTable("Player")
 
 function PLAYER:GetFishingRod()

--- a/lua/fishing_mod/sv_init.lua
+++ b/lua/fishing_mod/sv_init.lua
@@ -228,7 +228,7 @@ hook.Add("FishingModCaught", "FishingMod:Seagull", function(ply, entity)
 	--print("player",ply,"catch",entity)
 	if IsValid(ply) and IsValid(entity) then
 		--print("BEFORE RANDOM")
-		if math.random(3) ~= 1 then return end
+		if math.random(150) < math.Clamp(ply.fishingmod.seagull_deter or 1, 1, 100) then return end
 		--print("AFTER RANDOM")
 		local random = VectorRand()*2000
 		random.z = math.abs(random.z)
@@ -303,8 +303,7 @@ end)
 
 
 concommand.Add("fishing_mod_request_init", function(ply)
-	if ply.fishing_mod_spawned then return end
-	
+	if ply.fishingmod and ply.fishing_mod_spawned then return end
 	for key, entity in pairs(ents.GetAll()) do
 		if entity:GetNWBool("fishingmod catch") then
 			fishingmod.SetCatchInfo(entity, ply)

--- a/lua/fishing_mod/sv_init.lua
+++ b/lua/fishing_mod/sv_init.lua
@@ -53,10 +53,10 @@ hook.Add("CanTool", "Fishingmod:CanTool", function(ply, trace, tool)
 		return false		
 	end
 end)
-fishingmod.lastBaitSpawn = CurTime()
-
+fishingmod.bait_spawn_delay = 0.625
 concommand.Add("fishing_mod_buy_bait", function(ply, command, arguments)
-	if CurTime() >= fishingmod.lastBaitSpawn + 0.625 then
+	ply.fishingmod.last_bait_spawn = ply.fishingmod.last_bait_spawn or 0
+	if CurTime() >= ply.fishingmod.last_bait_spawn + fishingmod.bait_spawn_delay then
 		local type = table.concat(arguments, " ")
 		local rod = ply:GetFishingRod()
 		if not rod then return end
@@ -88,7 +88,7 @@ concommand.Add("fishing_mod_buy_bait", function(ply, command, arguments)
 		fishingmod.SetBaitInfo(bait)
 		hooky:SetPos(hooky:GetPos() + Vector(0, 0, (1 - util.QuickTrace(hooky:GetPos(), Vector(0, 0, -16) ).Fraction) * 16 ) )
 		fishingmod.HookBait(ply, bait, hooky)
-		fishingmod.lastBaitSpawn = CurTime()
+		ply.fishingmod.last_bait_spawn = CurTime()
 	end
 end)
 

--- a/lua/fishing_mod/sv_init.lua
+++ b/lua/fishing_mod/sv_init.lua
@@ -86,8 +86,10 @@ concommand.Add("fishing_mod_buy_bait", function(ply, command, arguments)
 		if not util.IsValidProp(bait:GetModel():lower()) then bait:PhysicsInitBox(Vector(1, 1, 1 ) * -7,Vector(1, 1, 1) * 7) end
 		
 		fishingmod.SetBaitInfo(bait)
-		hooky:SetPos(hooky:GetPos() + Vector(0, 0, (1 - util.QuickTrace(hooky:GetPos(), Vector(0, 0, -16) ).Fraction) * 16 ) )
-		fishingmod.HookBait(ply, bait, hooky)
+        if hooky then
+    		hooky:SetPos(hooky:GetPos() + Vector(0, 0, (1 - util.QuickTrace(hooky:GetPos(), Vector(0, 0, -16) ).Fraction) * 16 ) )
+    		fishingmod.HookBait(ply, bait, hooky)
+        end
 		ply.fishingmod.last_bait_spawn = CurTime()
 	end
 end)

--- a/lua/fishing_mod/sv_networking.lua
+++ b/lua/fishing_mod/sv_networking.lua
@@ -56,6 +56,7 @@ function fishingmod.UpdatePlayerInfo(ply, spawned)
 		net.WriteInt(ply.fishingmod.reel_speed, 16)
 		net.WriteInt(ply.fishingmod.string_length, 16)
 		net.WriteInt(ply.fishingmod.force, 16)
+        net.WriteInt(ply.fishingmod.seagull_deter or 0, 16)
 		net.WriteBool(spawned or false)
 	net.Broadcast()	
 end

--- a/lua/fishing_mod/sv_player_stats.lua
+++ b/lua/fishing_mod/sv_player_stats.lua
@@ -289,7 +289,7 @@ function fishingmod.GiveMoney(ply, amount)
 end
 
 function fishingmod.Pay(ply, money)
-	if ply.fishingmod.money > money then
+	if ply.fishingmod.money >= money then
 		fishingmod.TakeMoney(ply, money)
 		return true
 	end

--- a/lua/fishing_mod/sv_player_stats.lua
+++ b/lua/fishing_mod/sv_player_stats.lua
@@ -23,6 +23,7 @@ local PATH_GENERATOR_MIGRATION_ENABLED = {
 			reel_speed    = 0x20 + 1,
 			string_length = 0x28 + 1,
 			force         = 0x30 + 1,
+			seagull_deter = 0x38 + 1,
 		},
 		read = function (self, fh, name)
 			if name then -- read single info
@@ -54,6 +55,7 @@ local PATH_GENERATOR_MIGRATION_ENABLED = {
 			fh:WriteDouble(data.reel_speed    or 0)
 			fh:WriteDouble(data.string_length or 0)
 			fh:WriteDouble(data.force         or 0)
+			fh:WriteDouble(data.seagull_deter or 0)
 			fh:Close()
 			return true
 		end
@@ -350,6 +352,19 @@ function fishingmod.SetHookForce(ply, force, add_or_sub)
 	fishingmod.UpdatePlayerInfo(ply)
 end
 
+function fishingmod.SetSeagullDeter(ply, seagull_deter, add_or_sub)
+    if not ply.fishingmod.seagull_deter then fishingmod.InitPlayerStats(ply) end -- this is cursed but i see no other way atm
+	if add_or_sub == "add" then
+		ply.fishingmod.seagull_deter = ply.fishingmod.seagull_deter + seagull_deter
+	elseif add_or_sub == "sub" then
+		ply.fishingmod.seagull_deter = ply.fishingmod.seagull_deter - seagull_deter
+	else
+		ply.fishingmod.seagull_deter = seagull_deter
+	end
+	fishingmod.SavePlayerInfo(ply, "seagull_deter", ply.fishingmod.seagull_deter)
+	fishingmod.UpdatePlayerInfo(ply)
+end
+
 local fieldnames = {
 	"catches",
 	"exp",
@@ -357,7 +372,8 @@ local fieldnames = {
 	"length",
 	"reel_speed",
 	"string_length",
-	"force"
+	"force",
+	"seagull_deter"
 }
 
 function fishingmod.InitPlayerStats(ply)

--- a/lua/fishing_mod/sv_upgrades.lua
+++ b/lua/fishing_mod/sv_upgrades.lua
@@ -57,7 +57,7 @@ end
 
 function fishingmod.DowngradeReelSpeed(ply, amount)
 	amount = math.max(amount, 1)
-	if amount >= ply.fishingmod.string_length then return end
+	if amount >= ply.fishingmod.reel_speed then return end
 	fishingmod.SetRodReelSpeed(ply, amount, "sub")
 end
 
@@ -80,7 +80,7 @@ end
 
 function fishingmod.DowngradeHookForce(ply, amount)
 	amount = math.max(amount, 1)
-	if amount >= ply.fishingmod.string_length then return end
+	if amount >= ply.fishingmod.force then return end
 	fishingmod.SetHookForce(ply, amount, "sub")
 end
 
@@ -90,4 +90,28 @@ end)
 
 concommand.Add("fishingmod_downgrade_hook_force", function(ply, command, arguments)
 	fishingmod.DowngradeHookForce(ply, arguments[1])
+end)
+
+-- Seagull deterring
+
+function fishingmod.UpgradeSeagullDeter(ply, amount)
+    if ply.fishingmod.seagull_deter + amount > 100 then return end
+	local cost = amount * fishingmod.SeagullDeterPrice
+	if cost > ply.fishingmod.money then return end
+	fishingmod.TakeMoney(ply, cost)
+	fishingmod.SetSeagullDeter(ply, amount, "add")
+end
+
+function fishingmod.DowngradeSeagullDeter(ply, amount)
+	amount = math.max(amount, 1)
+	if amount >= ply.fishingmod.seagull_deter then return end
+	fishingmod.SetSeagullDeter(ply, amount, "sub")
+end
+
+concommand.Add("fishingmod_upgrade_seagull_deter", function(ply, command, arguments)
+	fishingmod.UpgradeSeagullDeter(ply, arguments[1])
+end)
+
+concommand.Add("fishingmod_downgrade_seagull_deter", function(ply, command, arguments)
+	fishingmod.DowngradeSeagullDeter(ply, arguments[1])
 end)

--- a/lua/weapons/weapon_fishing_rod.lua
+++ b/lua/weapons/weapon_fishing_rod.lua
@@ -34,7 +34,7 @@ end
 
 function SWEP:SecondaryAttack()
 	
-	
+
 	if SERVER then
 		if not IsValid(self.fishing_rod) or not IsValid(self:GetOwner()) or not self:GetOwner().fishingmod then return end
 		
@@ -57,7 +57,15 @@ if CLIENT then
 	SWEP.SlotPos = 1
 	SWEP.DrawAmmo = false
 	SWEP.DrawCrosshair	= false
-	
+	--SWEP.DrawCrosshair = true
+	function SWEP:Initialize()
+		if not self.hasMentioned and not game.SinglePlayer() then
+			if self:GetOwner() == LocalPlayer() then
+				chat.AddText(Color(0, 255, 0), "[Fishing Mod]", Color(255, 255, 255), ": Press 'B' by default to open the fishing mod menu. \nIf you bound 'B' to something else: bind <key> fishing_mod_menu.")
+				self.hasMentioned = true
+			end
+		end
+	end
 else
 	
 	AddCSLuaFile()
@@ -67,18 +75,21 @@ else
 	
 	function SWEP:Initialize()
 		self.distance = 0
-		self.lastowner=IsValid(self:GetOwner()) and self:GetOwner() or IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
+		self.lastowner = IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
 		self:SetHoldType("pistol")
 	end
 
 	function SWEP:Deploy()
-		self.lastowner=IsValid(self:GetOwner()) and self:GetOwner() or IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
+		self.lastowner = IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
 		if not IsValid(self.fishing_rod) then
 			self.fishing_rod = ents.Create("entity_fishing_rod")
 			if not self.fishing_rod or not self.fishing_rod:IsValid() or not self:GetOwner().fishingmod then
-				Msg"[FishingMod] Broken for "print(self:GetOwner(),self)
+				Msg"[Fishing Mod] Broken for "print(self:GetOwner(), self)
 				self:Remove()
 				return
+			elseif not self.hasMentioned and game.SinglePlayer() and IsValid(self:GetOwner()) then
+				self:GetOwner():ChatPrint("[Fishing Mod]: Press 'B' by default to open the fishing mod menu. \nIf you bound 'B' to something else: bind <key> fishing_mod_menu.")
+				self.hasMentioned = true
 			end
 			self.fishing_rod.dt.rod_length = self:GetOwner().fishingmod.length / 10 + 1
 			self.fishing_rod:Spawn()
@@ -116,11 +127,11 @@ else
 	end
 	
 	function SWEP:OwnerChanged() 
-		self.lastowner=IsValid(self:GetOwner()) and self:GetOwner() or IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
+		self.lastowner = IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
 	end
 	
 	function SWEP:OnDrop() 
-		self.lastowner=IsValid(self:GetOwner()) and self:GetOwner() or IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
+		self.lastowner = IsValid(self:GetOwner()) and self:GetOwner() or self.lastowner
 		if IsValid(self:GetOwner()) then
 		  self:KillRod() 
 		end

--- a/lua/weapons/weapon_fishing_rod.lua
+++ b/lua/weapons/weapon_fishing_rod.lua
@@ -83,6 +83,9 @@ else
 			self.fishing_rod = ents.Create("entity_fishing_rod")
 			if not self.fishing_rod or not self.fishing_rod:IsValid() or not self:GetOwner().fishingmod then
 				Msg"[Fishing Mod] Broken for "print(self:GetOwner(), self)
+                if SERVER then 
+                    self:GetOwner():ConCommand("fishing_mod_request_init") 
+                end
 				self:Remove()
 				return
 			elseif not self.hasMentioned and game.SinglePlayer() and IsValid(self:GetOwner()) then

--- a/lua/weapons/weapon_fishing_rod.lua
+++ b/lua/weapons/weapon_fishing_rod.lua
@@ -59,11 +59,9 @@ if CLIENT then
 	SWEP.DrawCrosshair	= false
 	--SWEP.DrawCrosshair = true
 	function SWEP:Initialize()
-		if not self.hasMentioned and not game.SinglePlayer() then
-			if self:GetOwner() == LocalPlayer() then
-				chat.AddText(Color(0, 255, 0), "[Fishing Mod]", Color(255, 255, 255), ": Press 'B' by default to open the fishing mod menu. \nIf you bound 'B' to something else: bind <key> fishing_mod_menu.")
-				self.hasMentioned = true
-			end
+		if not self.hasMentioned and not game.SinglePlayer() and self:GetOwner() == LocalPlayer() then
+			chat.AddText(Color(0, 255, 0), "[Fishing Mod]", Color(255, 255, 255), ": Press 'B' by default to open the fishing mod menu. \nIf you bound 'B' to something else: bind <key> fishing_mod_menu.")
+			self.hasMentioned = true
 		end
 	end
 else


### PR DESCRIPTION
+ui colors now customizable with a third tab in the menu named 'Customization'
+seagull ragdoll spawn only once now (sometimes spawned multiple when killed)
+bait hooking adjustments... so they dont get stuck in displacements and nocollide
+bait release timer so it does not reattach instantly
+bait spawn height offset addition to avoid creating black holes of bait
+removed broken cashreg model (it was the dod version i think)
+stove cooking offset higher since some stuff were not cooked at their set positions
+'b' now opens the menu if cvar fishing_mod_b_opens_always is 1 or greater
+could not buy bait if it was equal to the money player has.
+equipping the fishingrod now messages the player of default bind
+entities fishingrod, bobber and hook are no longer possible to "tool" and "property" (context menu)
+added crosshair to see where the player is aiming (also customizable color)
+minor fixes